### PR TITLE
Add grouping configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Issue

Pull requests from dependabot aren't grouped, so we end up with a bunch of separate pull requests that clutter the commits.

## Changes

' Add grouping configuration for dependabot, see [GitHub docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--) for more details on `groups`.

