### PR TITLE
Update Dockerfile and CI for v1.22.3 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - 'releases/**'
+    tags:
+      - v*
   pull_request:
     branches:
       - main
@@ -17,17 +19,19 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
-          images: openmodelica/build-deps
+          images: ghcr.io/openmodelica/build-deps
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           push: false

--- a/.github/workflows/publish-nexus.yml
+++ b/.github/workflows/publish-nexus.yml
@@ -1,0 +1,41 @@
+name: Publish Docker Image to Nexus
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  push_to_nexus:
+    name: Push Docker image to Nexus (docker.openmodelica.org)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6.0.2
+
+      - name: Login to Nexus Docker registry
+        uses: docker/login-action@v4.2.0
+        with:
+          registry: docker.openmodelica.org
+          username: ${{ secrets.NEXUS_OPENMODELICABOT_USER }}
+          password: ${{ secrets.NEXUS_OPENMODELICABOT_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: docker.openmodelica.org/build-deps
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,33 +3,78 @@ name: Publish Docker Image
 on:
   release:
     types: [published]
+  workflow_dispatch:
+
+# Required for cosign keyless (OIDC) to mint tokens
+permissions:
+  contents: read
+  packages: write
+  id-token: write # needed for signing the images with GitHub OIDC Token
 
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push Docker image to GitHub Container registry
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
-      
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: actions/checkout@v6.0.2
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4.2.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
-          images: openmodelica/build-deps
+          images: ghcr.io/openmodelica/build-deps
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
-          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          push: true
+
+      - name: Sign the images with GitHub OIDC Token (tag-based)
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          [ -n "${TAGS:-}" ] || { echo "No tags found"; exit 1; }
+          images=""
+          while IFS= read -r tag; do
+            tag="$(echo "$tag" | xargs)"   # trim whitespace
+            [ -z "$tag" ] && continue
+            images+="${tag} "
+            echo "Signing tag: ${tag}"
+            cosign sign --yes "${tag}"
+          done < <(echo "${TAGS:-}" | tr ',' '\n')
+
+      - name: Verify signatures (tag-based)
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          [ -n "${TAGS:-}" ] || { echo "No tags found"; exit 1; }
+          CERT_ID="https://github.com/${{ github.repository }}/.github/workflows/publish.yml@${{ github.ref }}"
+          CERT_ISSUER="https://token.actions.githubusercontent.com"
+          while IFS= read -r tag; do
+            tag="$(echo "$tag" | xargs)"
+            [ -z "$tag" ] && continue
+            echo "Verifying tag: ${tag}"
+            cosign verify \
+              --certificate-identity="${CERT_ID}" \
+              --certificate-oidc-issuer="${CERT_ISSUER}" \
+              "${tag}"
+          done < <(echo "${TAGS:-}" | tr ',' '\n')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6.0.2
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Only mark as latest when the tag is on the default branch
+          BASE_BRANCH=$(gh api repos/${{ github.repository }} --jq '.default_branch')
+          ON_DEFAULT=$(git branch -r --contains "${{ github.ref_name }}" | grep -qE "origin/${BASE_BRANCH}$" && echo true || echo false)
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            --verify-tag \
+            --latest="${ON_DEFAULT}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get install -qy \
   pocl-opencl-icd       \
   poppler-utils         \
   python3-pip           \
+  qttools5-dev          \
   qtwebengine5-dev      \
   subversion            \
   texlive-base          \
@@ -74,6 +75,90 @@ RUN apt-get install -qy \
   xsltproc              \
   xvfb                  \
   zip
+
+# Qt6 tools
+RUN apt-get install -qy                                                        \
+  libqt6concurrent6                                                            \
+  libqt6core5compat6                                                           \
+  libqt6core5compat6-dev                                                       \
+  libqt6core6                                                                  \
+  libqt6dbus6                                                                  \
+  libqt6designer6                                                              \
+  libqt6designercomponents6                                                    \
+  libqt6gui6                                                                   \
+  libqt6help6                                                                  \
+  libqt6labsanimation6                                                         \
+  libqt6labsfolderlistmodel6                                                   \
+  libqt6labsqmlmodels6                                                         \
+  libqt6labssettings6                                                          \
+  libqt6labssharedimage6                                                       \
+  libqt6labswavefrontmesh6                                                     \
+  libqt6network6                                                               \
+  libqt6opengl6                                                                \
+  libqt6opengl6-dev                                                            \
+  libqt6openglwidgets6                                                         \
+  libqt6pdf6                                                                   \
+  libqt6pdfquick6                                                              \
+  libqt6pdfwidgets6                                                            \
+  libqt6positioning6                                                           \
+  libqt6positioning6-plugins                                                   \
+  libqt6positioningquick6                                                      \
+  libqt6printsupport6                                                          \
+  libqt6qml6                                                                   \
+  libqt6qmlcore6                                                               \
+  libqt6qmllocalstorage6                                                       \
+  libqt6qmlmodels6                                                             \
+  libqt6qmlworkerscript6                                                       \
+  libqt6qmlxmllistmodel6                                                       \
+  libqt6quick6                                                                 \
+  libqt6quickcontrols2-6                                                       \
+  libqt6quickcontrols2impl6                                                    \
+  libqt6quickdialogs2-6                                                        \
+  libqt6quickdialogs2quickimpl6                                                \
+  libqt6quickdialogs2utils6                                                    \
+  libqt6quicklayouts6                                                          \
+  libqt6quickparticles6                                                        \
+  libqt6quickshapes6                                                           \
+  libqt6quicktemplates2-6                                                      \
+  libqt6quicktest6                                                             \
+  libqt6quickwidgets6                                                          \
+  libqt6serialport6                                                            \
+  libqt6sql6                                                                   \
+  libqt6sql6-sqlite                                                            \
+  libqt6svg6                                                                   \
+  libqt6svg6-dev                                                               \
+  libqt6svgwidgets6                                                            \
+  libqt6test6                                                                  \
+  libqt6uitools6                                                               \
+  libqt6waylandclient6                                                         \
+  libqt6waylandcompositor6                                                     \
+  libqt6waylandeglclienthwintegration6                                         \
+  libqt6waylandeglcompositorhwintegration6                                     \
+  libqt6webchannel6                                                            \
+  libqt6webchannel6-dev                                                        \
+  libqt6webengine6-data                                                        \
+  libqt6webenginecore6                                                         \
+  libqt6webenginecore6-bin                                                     \
+  libqt6webenginequick6                                                        \
+  libqt6webenginequickdelegatesqml6                                            \
+  libqt6webenginewidgets6                                                      \
+  libqt6webview6                                                               \
+  libqt6webviewquick6                                                          \
+  libqt6widgets6                                                               \
+  libqt6wlshellintegration6                                                    \
+  libqt6xml6                                                                   \
+  qt6-base-dev                                                                 \
+  qt6-base-dev-tools                                                           \
+  qt6-declarative-dev                                                          \
+  qt6-declarative-dev-tools                                                    \
+  qt6-l10n-tools                                                               \
+  qt6-tools-dev                                                                \
+  qt6-tools-dev-tools                                                          \
+  qt6-translations-l10n                                                        \
+  qt6-webengine-dev                                                            \
+  qt6-webengine-dev-tools                                                      \
+  qt6-webview-dev                                                              \
+  qt6-webview-plugins
 
 RUN wget https://raw.githubusercontent.com/OpenModelica/OpenModelicaBuildScripts/master/debian/control \
   && mk-build-deps --install -t 'apt-get --force-yes -y' control

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,42 @@
 FROM ubuntu:jammy
 
-LABEL org.opencontainers.image.authors="AnHeuermann"
+# Image / OCI metadata
+LABEL maintainer="AnHeuermann"
+LABEL description="OpenModelica build-deps Docker Image "
+LABEL organization="OpenModelica"
 
-ENV SHELL /bin/bash
+LABEL org.opencontainers.image.vendor="OpenModelica"
+LABEL org.opencontainers.image.authors="AnHeuermann"
+LABEL org.opencontainers.image.version="v1.22.3"
+LABEL org.opencontainers.image.description="OpenModelica build-deps Docker Image "
+LABEL org.opencontainers.image.source="https://github.com/OpenModelica/build-deps"
+LABEL org.opencontainers.image.license="MIT"
+
+ENV SHELL=/bin/bash
 
 # Ensure DEBIAN_FRONTEND is only set during build
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get upgrade -qy && apt-get dist-upgrade -qy
-RUN apt-get install -qy \
-  ca-certificates       \
-  curl                  \
-  gnupg                 \
-  lsb-release
-
 # Install build-deps of OpenModelica
-RUN curl -fsSL http://build.openmodelica.org/apt/openmodelica.asc | gpg --dearmor -o /usr/share/keyrings/openmodelica-keyring.gpg
-RUN echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt \
-  $(lsb_release -cs) nightly" | tee /etc/apt/sources.list.d/openmodelica.list > /dev/null
-RUN echo \
-  "deb-src [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt \
-  $(lsb_release -cs) nightly" | tee -a /etc/apt/sources.list.d/openmodelica.list > /dev/null
-RUN apt-get update && apt-get build-dep -qy openmodelica
+RUN apt-get update                                                                                                                          \
+  && apt-get upgrade -qy                                                                                                                    \
+  && apt-get dist-upgrade -qy                                                                                                               \
+  && apt-get install -qy                                                                                                                    \
+    ca-certificates                                                                                                                         \
+    curl                                                                                                                                    \
+    gnupg                                                                                                                                   \
+    lsb-release                                                                                                                             \
+  && curl -fsSL https://build.openmodelica.org/apt/openmodelica-2026.asc | gpg --dearmor -o /usr/share/keyrings/openmodelica-keyring.gpg    \
+  && echo                                                                                                                                   \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt      \
+    $(cat /etc/os-release | grep "\(UBUNTU\\|DEBIAN\\|VERSION\)_CODENAME" | sort | cut -d= -f 2 | head -1)                                  \
+    nightly" | tee /etc/apt/sources.list.d/openmodelica.list > /dev/null                                                                    \
+  && echo                                                                                                                                   \
+    "deb-src [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt  \
+    $(cat /etc/os-release | grep "\(UBUNTU\\|DEBIAN\\|VERSION\)_CODENAME" | sort | cut -d= -f 2 | head -1)                                  \
+    nightly" | tee -a /etc/apt/sources.list.d/openmodelica.list > /dev/null                                                                 \
+  && apt-get update                                                                                                                         \
+  && apt-get build-dep -qy openmodelica
 
 # Install additional dependencies, e.g. to build the User's Guide
 RUN apt-get install -qy \
@@ -49,6 +63,7 @@ RUN apt-get install -qy \
   pocl-opencl-icd       \
   poppler-utils         \
   python3-pip           \
+  qtwebengine5-dev      \
   subversion            \
   texlive-base          \
   texlive-bibtex-extra  \
@@ -69,9 +84,9 @@ RUN wget https://raw.githubusercontent.com/OpenModelica/OpenModelica/master/doc/
   && pip3 install --no-cache-dir --upgrade junit_xml simplejson svgwrite PyGithub
 
 # Set locale
-ENV LANGUAGE en_US:en
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 RUN apt-get install -qy locales
 
 # Clean

--- a/README.md
+++ b/README.md
@@ -16,20 +16,13 @@ docker build --pull --no-cache --tag build-deps:$TAG .
 
 ## Upload
 
-The [publish.yml](./.github/workflows/publish.yml) workflow will build and upload the
-Docker image to [openmodelica/build-deps](https://hub.docker.com/repository/docker/openmodelica/build-deps)
+The [publish.yml](./.github/workflows/publish.yml) workflow will build, sign and
+upload the Docker image to
+[GitHub Container registry](https://github.com/OpenModelica/openmodelica-build-deps/pkgs/container/build-deps)
 for each release.
-
-To do it manually run:
-
-```bash
-export REGISTRY=openmodelica
-export TAG=v1.22.3
-docker login
-docker image tag build-deps:$TAG $REGISTRY/build-deps:$TAG
-docker push $REGISTRY/build-deps:$TAG
-```
 
 ## License
 
+The original Dockerfile was taken from
+[OpenModelica/OpenModelicaBuildScripts](https://github.com/OpenModelica/OpenModelicaBuildScripts).
 See [LICENSE.md](./LICENSE.md).


### PR DESCRIPTION
## Issue

OpenModelica GPG key in v1.22.2 is outdated.
We have multiple images for building with Qt5 and Qt6 on Ubuntu Jammy.

## Changes

- Add qtwebengine5-dev (from [releases/v1.22-qtwebengine](https://github.com/OpenModelica/build-deps/tree/releases/v1.22-qtwebengine) branch)
- Add Qt6 tools (from https://github.com/OpenModelica/OpenModelicaBuildScripts/blob/master/docker/Dockerfile.build-deps-v1.22.6-qttools)
- Switch to new OpenModelica GPG key (openmodelica-2026.asc) required for Debian 13+ compatibility; old SHA1-based key is being retired
- Add OCI image labels (vendor, version, source, license, description)
- Consolidate initial apt setup into a single RUN layer
- Replace lsb_release with /etc/os-release for distro codename detection
- Sync .github from main: migrate registry from Docker Hub to GHCR, bump action versions, add cosign image signing, group dependabot updates