### PR TITLE
Debian Trixie Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM ubuntu:noble
+FROM debian:trixie
 
 # Image / OCI metadata
 LABEL maintainer="AnHeuermann"
-LABEL description="OpenModelica build-deps Docker Image"
+LABEL description="OpenModelica build-deps Docker Image for Debian Trixie"
 LABEL organization="OpenModelica"
 
 LABEL org.opencontainers.image.vendor="OpenModelica"
 LABEL org.opencontainers.image.authors="AnHeuermann"
-LABEL org.opencontainers.image.version="v1.26.1"
-LABEL org.opencontainers.image.description="OpenModelica build-deps Docker Image "
-LABEL org.opencontainers.image.source="https://github.com/OpenModelica/build-deps"
+LABEL org.opencontainers.image.version="trixie.nightly.amd64"
+LABEL org.opencontainers.image.description="OpenModelica build-deps Docker Image for Debian Trixie"
+LABEL org.opencontainers.image.source="https://github.com/OpenModelica/build-deps/tree/releases/trixie/v1.27"
 LABEL org.opencontainers.image.license="MIT"
 
 ENV SHELL=/bin/bash
@@ -17,84 +17,106 @@ ENV SHELL=/bin/bash
 # Ensure DEBIAN_FRONTEND is only set during build
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install OpenModelica build-deps
-RUN apt-get update                                                                                                                          \
-  && apt-get upgrade -qy                                                                                                                    \
-  && apt-get dist-upgrade -qy                                                                                                               \
-  && apt-get install -qy                                                                                                                    \
-    ca-certificates                                                                                                                         \
-    curl                                                                                                                                    \
-    gnupg                                                                                                                                   \
-    lsb-release                                                                                                                             \
-  && curl -fsSL https://build.openmodelica.org/apt/openmodelica.asc | gpg --dearmor -o /usr/share/keyrings/openmodelica-keyring.gpg         \
-  && echo                                                                                                                                   \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt      \
-    $(cat /etc/os-release | grep "\(UBUNTU\\|DEBIAN\\|VERSION\)_CODENAME" | sort | cut -d= -f 2 | head -1)                                  \
-    nightly" | tee /etc/apt/sources.list.d/openmodelica.list > /dev/null                                                                    \
-  && echo                                                                                                                                   \
-    "deb-src [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt  \
-    $(cat /etc/os-release | grep "\(UBUNTU\\|DEBIAN\\|VERSION\)_CODENAME" | sort | cut -d= -f 2 | head -1)                                  \
-    nightly" | tee -a /etc/apt/sources.list.d/openmodelica.list > /dev/null                                                                 \
-  && apt-get update                                                                                                                         \
-  && apt-get build-dep -qy openmodelica                                                                                                     \
-  && apt-get clean                                                                                                                          \
-  && rm -rf /var/lib/apt/lists/*
+# Install OpenModelica GPG key and
+RUN apt-get update                                                                                                                                               \
+  && apt-get upgrade -qy                                                                                                                                         \
+  && apt-get dist-upgrade -qy                                                                                                                                    \
+  && apt-get install -qy                                                                                                                                         \
+    ca-certificates                                                                                                                                              \
+    curl                                                                                                                                                         \
+    gnupg                                                                                                                                                        \
+    lsb-release                                                                                                                                                  \
+  && curl -fsSL https://build.openmodelica.org/apt/openmodelica.asc | gpg --dearmor -o /usr/share/keyrings/openmodelica-keyring.gpg                              \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt trixie nightly"     \
+    | tee /etc/apt/sources.list.d/openmodelica.list > /dev/null                                                                                                  \
+  && echo "deb-src [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt trixie nightly" \
+    | tee -a /etc/apt/sources.list.d/openmodelica.list > /dev/null                                                                                               \
+  && apt-get update
 
-# Install additional dependencies
+# Install:
+#   - Packages from OpenModelica build dependencies
 #   - tools to build the User's Guide
-#   - Qt5, Qt6 packages
-RUN apt-get update                                                             \
-  && apt-get install -qy                                                       \
-    aspell                                                                     \
-    bibtex2html                                                                \
-    bison                                                                      \
-    ccache                                                                     \
-    clang-tools                                                                \
-    devscripts                                                                 \
-    docker.io                                                                  \
-    doxygen                                                                    \
-    equivs                                                                     \
-    flex                                                                       \
-    git                                                                        \
-    gnuplot-nox                                                                \
-    inkscape                                                                   \
-    intel-opencl-icd                                                           \
-    latexmk                                                                    \
-    libcurl4-gnutls-dev                                                        \
-    libmldbm-perl                                                              \
-    libqt6core5compat6-dev                                                     \
-    libqt6opengl6-dev                                                          \
-    libqt6openglwidgets6                                                       \
-    libqt6svg6-dev                                                             \
-    locales                                                                    \
-    ocl-icd-opencl-dev                                                         \
-    opencl-headers                                                             \
-    pandoc                                                                     \
-    pocl-opencl-icd                                                            \
-    poppler-utils                                                              \
-    python3-pip                                                                \
-    python3-venv                                                               \
-    qt6-base-dev                                                               \
-    qt6-httpserver-dev                                                         \
-    qt6-scxml-dev                                                              \
-    qt6-tools-dev                                                              \
-    qt6-tools-dev-tools                                                        \
-    qt6-webengine-dev                                                          \
-    qt6-httpserver-dev                                                         \
-    qt6-websockets-dev                                                         \
-    qtwebengine5-dev                                                           \
-    subversion                                                                 \
-    texlive-base                                                               \
-    texlive-bibtex-extra                                                       \
-    texlive-lang-greek                                                         \
-    texlive-latex-extra                                                        \
-    unzip                                                                      \
-    wget                                                                       \
-    xsltproc                                                                   \
-    xvfb                                                                       \
-    zip                                                                        \
-  && apt-get clean                                                             \
-  && rm -rf /var/lib/apt/lists/*
+#   - Qt6 packages
+RUN apt-get install -qy                                                        \
+  aspell                                                                       \
+  autoconf                                                                     \
+  automake                                                                     \
+  bibtex2html                                                                  \
+  bison                                                                        \
+  build-essential                                                              \
+  ccache                                                                       \
+  clang                                                                        \
+  clang-tools                                                                  \
+  cmake                                                                        \
+  debhelper                                                                    \
+  default-jdk                                                                  \
+  devscripts                                                                   \
+  docker.io                                                                    \
+  doxygen                                                                      \
+  equivs                                                                       \
+  flex                                                                         \
+  gfortran                                                                     \
+  git                                                                          \
+  gnuplot-nox                                                                  \
+  inkscape                                                                     \
+  latexmk                                                                      \
+  libboost-all-dev                                                             \
+  libcurl4-gnutls-dev                                                          \
+  libexpat1-dev                                                                \
+  libffi-dev                                                                   \
+  libhdf5-dev                                                                  \
+  libhwloc-dev                                                                 \
+  liblapack-dev                                                                \
+  liblpsolve55-dev                                                             \
+  libmldbm-perl                                                                \
+  libncurses-dev                                                               \
+  libomniorb4-dev                                                              \
+  libomp-dev                                                                   \
+  libopenscenegraph-dev                                                        \
+  libqt6opengl6-dev                                                            \
+  libqt6openglwidgets6                                                         \
+  libreadline-dev                                                              \
+  libsqlite3-dev                                                               \
+  libtool                                                                      \
+  libxcursor-dev                                                               \
+  libxi-dev                                                                    \
+  libxinerama-dev                                                              \
+  libxrandr2                                                                   \
+  locales                                                                      \
+  lsb-release                                                                  \
+  ocl-icd-opencl-dev                                                           \
+  omniidl                                                                      \
+  opencl-headers                                                               \
+  pandoc                                                                       \
+  pkg-config                                                                   \
+  pocl-opencl-icd                                                              \
+  poppler-utils                                                                \
+  python3-pip                                                                  \
+  python3-venv                                                                 \
+  qt6-5compat-dev                                                              \
+  qt6-base-dev                                                                 \
+  qt6-base-dev-tools                                                           \
+  qt6-httpserver-dev                                                           \
+  qt6-l10n-tools                                                               \
+  qt6-scxml-dev                                                                \
+  qt6-svg-dev                                                                  \
+  qt6-tools-dev                                                                \
+  qt6-tools-dev-tools                                                          \
+  qt6-translations-l10n                                                        \
+  qt6-webengine-dev                                                            \
+  qt6-webengine-dev-tools                                                      \
+  qt6-websockets-dev                                                           \
+  subversion                                                                   \
+  texlive-base                                                                 \
+  texlive-bibtex-extra                                                         \
+  texlive-lang-greek                                                           \
+  texlive-latex-extra                                                          \
+  unzip                                                                        \
+  uuid-dev                                                                     \
+  wget                                                                         \
+  xsltproc                                                                     \
+  xvfb                                                                         \
+  zip
 
 # Install Python packages in a default virtual environment
 # Use permalink for doc/UsersGuide/source/requirements.txt to keep builds
@@ -115,3 +137,7 @@ RUN pip install --no-cache-dir                                                 \
 ENV LANGUAGE=en_US:en
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
+
+# Clean
+RUN apt-get clean \
+  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,64 +17,60 @@ ENV SHELL=/bin/bash
 # Ensure DEBIAN_FRONTEND is only set during build
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install OpenModelica GPG key and
-RUN apt-get update                                                                                                                                               \
-  && apt-get upgrade -qy                                                                                                                                         \
-  && apt-get dist-upgrade -qy                                                                                                                                    \
-  && apt-get install -qy                                                                                                                                         \
-    ca-certificates                                                                                                                                              \
-    curl                                                                                                                                                         \
-    gnupg                                                                                                                                                        \
-    lsb-release                                                                                                                                                  \
-  && curl -fsSL https://build.openmodelica.org/apt/openmodelica.asc | gpg --dearmor -o /usr/share/keyrings/openmodelica-keyring.gpg                              \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt trixie nightly"     \
-    | tee /etc/apt/sources.list.d/openmodelica.list > /dev/null                                                                                                  \
-  && echo "deb-src [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt trixie nightly" \
-    | tee -a /etc/apt/sources.list.d/openmodelica.list > /dev/null                                                                                               \
+# Install OpenModelica GPG key
+RUN apt-get update                                                             \
+  && apt-get upgrade -qy                                                       \
+  && apt-get dist-upgrade -qy                                                  \
+  && apt-get install -qy                                                       \
+    ca-certificates                                                            \
+    curl                                                                       \
+    gnupg                                                                      \
+    lsb-release                                                                \
+  && KEYRING=/usr/share/keyrings/openmodelica-keyring.gpg                      \
+  && ARCH=$(dpkg --print-architecture)                                         \
+  && REPO="https://build.openmodelica.org/apt"                                 \
+  && curl -fsSL ${REPO}/openmodelica.asc                                       \
+    | gpg --dearmor -o ${KEYRING}                                              \
+  && echo "deb [arch=${ARCH} signed-by=${KEYRING}] ${REPO} trixie nightly"     \
+    | tee /etc/apt/sources.list.d/openmodelica.list                            \
+  && echo "deb-src [arch=${ARCH} signed-by=${KEYRING}] ${REPO} trixie nightly" \
+    | tee -a /etc/apt/sources.list.d/openmodelica.list                         \
   && apt-get update
 
-# Install:
-#   - Packages from OpenModelica build dependencies
-#   - tools to build the User's Guide
-#   - Qt6 packages
+# Install Debian build dependencies
+# From https://github.com/OpenModelica/OpenModelicaBuildScripts/blob/37b564c1674023a5afb7517e408ffd9bd174a59c/debian/control
+# Qt5 dependencies skipped
 RUN apt-get install -qy                                                        \
-  aspell                                                                       \
   autoconf                                                                     \
   automake                                                                     \
-  bibtex2html                                                                  \
-  bison                                                                        \
   build-essential                                                              \
-  ccache                                                                       \
   clang                                                                        \
-  clang-tools                                                                  \
   cmake                                                                        \
   debhelper                                                                    \
   default-jdk                                                                  \
   devscripts                                                                   \
-  docker.io                                                                    \
-  doxygen                                                                      \
   equivs                                                                       \
-  flex                                                                         \
   gfortran                                                                     \
-  git                                                                          \
-  gnuplot-nox                                                                  \
-  inkscape                                                                     \
-  latexmk                                                                      \
   libboost-all-dev                                                             \
+  libboost-dev                                                                 \
+  libboost-filesystem-dev                                                      \
+  libboost-program-options-dev                                                 \
+  libboost-serialization-dev                                                   \
+  libboost-system-dev                                                          \
   libcurl4-gnutls-dev                                                          \
   libexpat1-dev                                                                \
+  libexpat1-dev                                                                \
   libffi-dev                                                                   \
-  libhdf5-dev                                                                  \
+  libhdf5-serial-dev                                                           \
   libhwloc-dev                                                                 \
   liblapack-dev                                                                \
+  liblapack-dev                                                                \
   liblpsolve55-dev                                                             \
-  libmldbm-perl                                                                \
-  libncurses-dev                                                               \
+  libncurses5-dev                                                              \
   libomniorb4-dev                                                              \
   libomp-dev                                                                   \
+  libopengl-dev                                                                \
   libopenscenegraph-dev                                                        \
-  libqt6opengl6-dev                                                            \
-  libqt6openglwidgets6                                                         \
   libreadline-dev                                                              \
   libsqlite3-dev                                                               \
   libtool                                                                      \
@@ -82,23 +78,104 @@ RUN apt-get install -qy                                                        \
   libxi-dev                                                                    \
   libxinerama-dev                                                              \
   libxrandr2                                                                   \
-  locales                                                                      \
-  lsb-release                                                                  \
-  ocl-icd-opencl-dev                                                           \
   omniidl                                                                      \
+  openscenegraph                                                               \
+  pkg-config                                                                   \
+  unzip                                                                        \
+  uuid-dev                                                                     \
+  wget                                                                         \
+  zip
+
+# Install additional dependencies:
+#   - Tools for the User's Guide
+RUN apt-get install -qy                                                        \
+  aspell                                                                       \
+  bibtex2html                                                                  \
+  bison                                                                        \
+  ccache                                                                       \
+  clang-tools                                                                  \
+  docker.io                                                                    \
+  doxygen                                                                      \
+  flex                                                                         \
+  git                                                                          \
+  gnuplot-nox                                                                  \
+  inkscape                                                                     \
+  latexmk                                                                      \
+  libmldbm-perl                                                                \
+  libsaxonb-java                                                               \
+  ocl-icd-opencl-dev                                                           \
   opencl-headers                                                               \
   pandoc                                                                       \
-  pkg-config                                                                   \
   pocl-opencl-icd                                                              \
   poppler-utils                                                                \
   python3-pip                                                                  \
-  python3-venv                                                                 \
+  python3.13-venv                                                              \
+  subversion                                                                   \
+  texlive-base                                                                 \
+  texlive-bibtex-extra                                                         \
+  texlive-lang-greek                                                           \
+  texlive-latex-extra                                                          \
+  xsltproc                                                                     \
+  xvfb
+
+# Install Qt6 tools
+RUN apt-get install -qy                                                        \
+  libqt6concurrent6                                                            \
+  libqt6core5compat6                                                           \
+  libqt6core5compat6-dev                                                       \
+  libqt6core6                                                                  \
+  libqt6dbus6                                                                  \
+  libqt6designer6                                                              \
+  libqt6designercomponents6                                                    \
+  libqt6gui6                                                                   \
+  libqt6help6                                                                  \
+  libqt6network6                                                               \
+  libqt6opengl6                                                                \
+  libqt6opengl6-dev                                                            \
+  libqt6openglwidgets6                                                         \
+  libqt6pdf6                                                                   \
+  libqt6pdfquick6                                                              \
+  libqt6pdfwidgets6                                                            \
+  libqt6positioning6                                                           \
+  libqt6positioning6-plugins                                                   \
+  libqt6positioningquick6                                                      \
+  libqt6printsupport6                                                          \
+  libqt6qml6                                                                   \
+  libqt6qmlmodels6                                                             \
+  libqt6qmlworkerscript6                                                       \
+  libqt6quick6                                                                 \
+  libqt6quickcontrols2-6                                                       \
+  libqt6quickshapes6                                                           \
+  libqt6quicktemplates2-6                                                      \
+  libqt6quicktest6                                                             \
+  libqt6quickwidgets6                                                          \
+  libqt6serialport6                                                            \
+  libqt6sql6                                                                   \
+  libqt6sql6-sqlite                                                            \
+  libqt6svg6                                                                   \
+  libqt6svg6-dev                                                               \
+  libqt6svgwidgets6                                                            \
+  libqt6test6                                                                  \
+  libqt6uitools6                                                               \
+  libqt6waylandclient6                                                         \
+  libqt6waylandcompositor6                                                     \
+  libqt6webchannel6                                                            \
+  libqt6webengine6-data                                                        \
+  libqt6webenginecore6                                                         \
+  libqt6webenginecore6-bin                                                     \
+  libqt6webenginequick6                                                        \
+  libqt6webenginewidgets6                                                      \
+  libqt6webview6                                                               \
+  libqt6widgets6                                                               \
+  libqt6wlshellintegration6                                                    \
+  libqt6xml6                                                                   \
   qt6-5compat-dev                                                              \
   qt6-base-dev                                                                 \
   qt6-base-dev-tools                                                           \
+  qt6-declarative-dev                                                          \
+  qt6-declarative-dev-tools                                                    \
   qt6-httpserver-dev                                                           \
   qt6-l10n-tools                                                               \
-  qt6-scxml-dev                                                                \
   qt6-svg-dev                                                                  \
   qt6-tools-dev                                                                \
   qt6-tools-dev-tools                                                          \
@@ -106,17 +183,8 @@ RUN apt-get install -qy                                                        \
   qt6-webengine-dev                                                            \
   qt6-webengine-dev-tools                                                      \
   qt6-websockets-dev                                                           \
-  subversion                                                                   \
-  texlive-base                                                                 \
-  texlive-bibtex-extra                                                         \
-  texlive-lang-greek                                                           \
-  texlive-latex-extra                                                          \
-  unzip                                                                        \
-  uuid-dev                                                                     \
-  wget                                                                         \
-  xsltproc                                                                     \
-  xvfb                                                                         \
-  zip
+  qt6-webview-dev                                                              \
+  qt6-webview-plugins
 
 # Install Python packages in a default virtual environment
 # Use permalink for doc/UsersGuide/source/requirements.txt to keep builds

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ When creating a release form a tag the
 
 ### Debian based Images
 
-- 12 Bookworm
-- 11 Bullseye
+- 13 Trixie
+  - [releases/debian/trixie/nightly](https://github.com/OpenModelica/build-deps/tree/releases/debian/trixie/nightly)
 
 ### CentOS based Images
 
@@ -41,7 +41,7 @@ When creating a release form a tag the
 ## Build
 
 ```bash
-export TAG=v1.26.1
+export TAG=trixie.nightly.amd64
 docker build --pull --no-cache --tag build-deps:$TAG .
 ```
 


### PR DESCRIPTION
## Issue

We don't have a Debian trixie build-deps image yet.
This will add `trixie.nightly.amd64`.

Partially related to https://github.com/OpenModelica/OpenModelica/issues/15331.