### PR TITLE
Allow re-tagging of commits

### DIFF
--- a/.github/workflows/publish-nexus.yml
+++ b/.github/workflows/publish-nexus.yml
@@ -2,7 +2,7 @@ name: Publish Docker Image to Nexus
 
 on:
   release:
-    types: [published]
+    types: [published, edited]
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish Docker Image
 
 on:
   release:
-    types: [published]
+    types: [published, edited]
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,22 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v6.0.3
 
-      - name: Create release
+      - name: Create or update release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Only mark as latest when the tag is on the default branch
           BASE_BRANCH=$(gh api repos/${{ github.repository }} --jq '.default_branch')
           ON_DEFAULT=$(git branch -r --contains "${{ github.ref_name }}" | grep -qE "origin/${BASE_BRANCH}$" && echo true || echo false)
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes \
-            --verify-tag \
-            --latest="${ON_DEFAULT}"
+          if gh release view "${{ github.ref_name }}" &>/dev/null; then
+            gh release edit "${{ github.ref_name }}" \
+              --title "${{ github.ref_name }}" \
+              --generate-notes \
+              --latest="${ON_DEFAULT}"
+          else
+            gh release create "${{ github.ref_name }}" \
+              --title "${{ github.ref_name }}" \
+              --generate-notes \
+              --verify-tag \
+              --latest="${ON_DEFAULT}"
+          fi


### PR DESCRIPTION
We want to be able to re-tag commits after some updates and automate the re-release of the image to GHCR / Nexus.