### PR TITLE
Adding FMPy Python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,7 @@ RUN apt-get install -qy                                                        \
 
 # Python packages
 RUN pip3 install --no-cache-dir                                                \
+    fmpy                                                                       \
     junit_xml                                                                  \
     ompython==3.6.0                                                            \
     PyGithub                                                                   \


### PR DESCRIPTION
## Issue

* Some FMI tests could use a 3rd-party FMI importing tool.

## Changes

* Adding latest version of FMPy (currently v0.3.29)
* FMPy can be used with `fmpy` or `ython3 -m fmpy`.