### PR TITLE
Adding FMpy and jq

### DIFF
--- a/.ci/matrix.yml
+++ b/.ci/matrix.yml
@@ -38,7 +38,6 @@ images:
       VERSION: "26.04"
     addons:
       - rust
-      - cmake-4
       - debug
 
   - os: ubuntu

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude/
 .venv/
 .vscode/
 CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ main
   OpenModelica (distro packages + common tooling: TeX, Qt, Python venv,
   ccache, …). This is what most CI jobs use.
 - **Add-on image** — the base plus *one* thing the distro package manager can't
-  provide or that needs a pinned version (e.g. CMake 4). Realised as an extra
+  provide or that needs a pinned version (e.g. CMake 4). Realized as an extra
   build **stage** (`FROM` the base stage) in the same Dockerfile, so shared
   layers are reused from cache.
 
@@ -71,15 +71,15 @@ OpenModelica release needs a frozen environment it pins the **immutable** tag.
 
 ### Currently provided images
 
-| OS / version             | Base tag               | Add-ons                    | Dockerfile           | Status      |
-| ------------------------ | ---------------------- | -------------------------- | -------------------- | ----------- |
-| Ubuntu 26.04 (Resolute)  | `ubuntu-26.04`         | `rust`, `cmake-4`, `debug` | `apt/Dockerfile`     | implemented |
-| Ubuntu 24.04 (Noble)     | `ubuntu-24.04`         | `cmake-4`, `debug`         | `apt/Dockerfile`     | implemented |
-| Ubuntu 22.04 (Jammy)     | `ubuntu-22.04`         | `debug`                    | `apt/Dockerfile`     | implemented |
-| Debian 13 (Trixie)       | `debian-13`            | `cmake-4`, `debug`         | `apt/Dockerfile`     | implemented |
-| Debian 12 (Bookworm)     | `debian-12`            | `cmake-4`, `debug`         | `apt/Dockerfile`     | implemented |
-| Fedora, AlmaLinux, RHEL  | `<os>-<ver>`           | –                          | `rpm/Dockerfile`     | planned     |
-| Arch Linux (rolling)     | `arch-rolling`         | –                          | `pacman/Dockerfile`  | placeholder |
+| OS / version            | Base tag       | Add-ons            | Dockerfile          | Status      |
+| ----------------------- | -------------- | ------------------ | ------------------- | ----------- |
+| Ubuntu 26.04 (Resolute) | `ubuntu-26.04` | `rust`, `debug`    | `apt/Dockerfile`    | implemented |
+| Ubuntu 24.04 (Noble)    | `ubuntu-24.04` | `cmake-4`, `debug` | `apt/Dockerfile`    | implemented |
+| Ubuntu 22.04 (Jammy)    | `ubuntu-22.04` | `debug`            | `apt/Dockerfile`    | implemented |
+| Debian 13 (Trixie)      | `debian-13`    | `cmake-4`, `debug` | `apt/Dockerfile`    | implemented |
+| Debian 12 (Bookworm)    | `debian-12`    | `cmake-4`, `debug` | `apt/Dockerfile`    | implemented |
+| Fedora, AlmaLinux, RHEL | `<os>-<ver>`   | –                  | `rpm/Dockerfile`    | planned     |
+| Arch Linux (rolling)    | `arch-rolling` | –                  | `pacman/Dockerfile` | placeholder |
 
 ## Build locally
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,11 +13,11 @@ Releases are driven entirely by **git tags**; you never push images by hand.
 <os>-<os-version>-<semver>
 ```
 
-| Part | Example | Notes |
-| --- | --- | --- |
-| `<os>` | `ubuntu` | A directory at the repo root holding `<os>/Dockerfile`. |
-| `<os-version>` | `24.04`, `13`, `rolling` | Selects the version (a build-arg) within that OS. |
-| `<semver>` | `2.1.0` | **This repository's** version (the recipe), independent of OpenModelica. `MAJOR.MINOR.PATCH`. |
+| Part           | Example                  | Notes                                                                                         |
+| -------------- | ------------------------ | --------------------------------------------------------------------------------------------- |
+| `<os>`         | `ubuntu`                 | A directory at the repo root holding `<os>/Dockerfile`.                                       |
+| `<os-version>` | `24.04`, `13`, `rolling` | Selects the version (a build-arg) within that OS.                                             |
+| `<semver>`     | `2.1.0`                  | **This repository's** version (the recipe), independent of OpenModelica. `MAJOR.MINOR.PATCH`. |
 
 The pair `<os>-<os-version>` must match an entry in
 [.ci/matrix.yml][ci-matrix] (you can list valid prefixes with

--- a/apt/Dockerfile
+++ b/apt/Dockerfile
@@ -81,6 +81,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Use permalink for doc/UsersGuide/source/requirements.txt to keep builds
 # deterministic.
 RUN pip install --no-cache-dir \
+    fmpy \
     junit_xml \
     lxml \
     ompython==3.6.0 \
@@ -177,6 +178,7 @@ ARG COMMON_PKGS="\
     git \
     gnuplot-nox \
     inkscape \
+    jq \
     latexmk \
     libcurl4-gnutls-dev \
     libmldbm-perl \


### PR DESCRIPTION
## Issue

FMPy is needed for the testsuite:

```bash
Traceback (most recent call last):
  File "/var/lib/jenkins/ws/OpenModelica_PR-15957/testsuite/openmodelica/fmi/ModelExchange/3.0/fmi3_msl_engine1a.mos_temp8387/../../simulate_fmu_fmpy.py", line 23, in <module>
    from fmpy import simulate_fmu
ModuleNotFoundError: No module named 'fmpy'
```

`jq` is needed for the testsuite:

```bash
mkdir -p extra/org.openmodelica
jq --arg regex \"__Optimization|__Estimation\" -f \"/var/lib/jenkins2/ws/OpenModelica_PR-15957/build/bin/../share/omc/scripts/filter-annotations.jq\" ModelWithAnnotations_modelInstance.json > extra/org.openmodelica/modelAnnotations.json
/bin/sh: 1: jq: not found
make: *** [ModelWithAnnotations_FMU.makefile:111: ModelWithAnnotations.fmu] Error 127
```

## Changes

Adding FMPy to the APT based images.