### PR TITLE
Simplify push

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Build one image (base + all its add-ons) without pushing.
+#
+# Layers are written to the GitHub Actions cache (type=gha) so the
+# publish-ghcr and publish-nexus jobs can restore them via --cache-from
+# instead of rebuilding from scratch.
+#
+# Required environment variables:
+#   BASE_TAG    Moving base tag, e.g. ubuntu-24.04
+#   CONTEXT     Docker build context path
+#   DOCKERFILE  Path to the Dockerfile
+#   TARGET      Build stage for the base image (empty = final stage)
+#   BUILD_ARGS  Space-separated KEY=VALUE build arguments
+#   ADDONS      Space-separated add-on stage names
+set -euo pipefail
+
+: "${BASE_TAG:?BASE_TAG is required}"
+: "${CONTEXT:?CONTEXT is required}"
+: "${DOCKERFILE:?DOCKERFILE is required}"
+
+# Common build-args (e.g. DISTRO=ubuntu VERSION=24.04) apply to every stage.
+common_args=()
+for kv in ${BUILD_ARGS:-}; do
+  common_args+=(--build-arg "${kv}")
+done
+
+# 1. Base image: the image's `target` stage (or the final stage).
+base_target_arg=()
+[ -n "${TARGET:-}" ] && base_target_arg=(--target "${TARGET}")
+echo "::group::Building base ${BASE_TAG}"
+docker buildx build \
+  --file "${DOCKERFILE}" \
+  "${common_args[@]}" "${base_target_arg[@]}" \
+  --cache-to "type=gha,mode=max,scope=${BASE_TAG}" \
+  --tag "local/build-deps:${BASE_TAG}" \
+  --load \
+  "${CONTEXT}"
+echo "::endgroup::"
+
+# 2. Add-ons: each is a --target stage in the same Dockerfile.
+for addon in ${ADDONS:-}; do
+  echo "::group::Building add-on ${addon}"
+  docker buildx build \
+    --file "${DOCKERFILE}" \
+    "${common_args[@]}" --target "${addon}" \
+    --cache-to "type=gha,mode=max,scope=${BASE_TAG}-${addon}" \
+    --tag "local/build-deps:${BASE_TAG}-${addon}" \
+    --load \
+    "${CONTEXT}"
+  echo "::endgroup::"
+done

--- a/.ci/matrix.py
+++ b/.ci/matrix.py
@@ -34,12 +34,20 @@ and answers questions for the GitHub Actions workflows:
 
         Intended to be consumed with ``eval "$(python .ci/matrix.py image …)"``.
 
-    matrix.py publish-matrix <date>
-        Print, on one line, a JSON array of ``{"tag": "<base_tag>-<date>"}``
-        objects for every image in the matrix. Used by the scheduled workflow
-        to build the publish job matrix with date-stamped immutable tags::
+    matrix.py publish-matrix [<semver>]
+        Print, on one line, a JSON array of publish-job descriptors for every
+        image in the matrix.
 
-            [{"tag":"ubuntu-24.04-2026.06.23"},{"tag":"ubuntu-22.04-2026.06.23"}]
+        Without ``<semver>``: returns moving-tag-only descriptors (used when
+        publishing from ``main`` or the scheduled rebuild)::
+
+            [{"tag":"ubuntu-24.04"},{"tag":"ubuntu-22.04"}]
+
+        With ``<semver>``: returns immutable-tag descriptors synthesized from a
+        global release tag such as ``v2.1.0`` (pass the version without the
+        leading ``v``)::
+
+            [{"tag":"ubuntu-24.04-2.1.0"},{"tag":"ubuntu-22.04-2.1.0"}]
 """
 
 from __future__ import annotations
@@ -94,23 +102,43 @@ def cmd_all():
     print(json.dumps(load_images(), separators=(",", ":")))
 
 
-def cmd_publish_matrix(date: str):
+def cmd_publish_matrix(semver: str | None = None):
     images = load_images()
-    result = [{"tag": f"{img['base_tag']}-{date}"} for img in images]
+    if semver is None:
+        result = [{"tag": img["base_tag"]} for img in images]
+    else:
+        result = [{"tag": f"{img['base_tag']}-{semver}"} for img in images]
     print(json.dumps(result, separators=(",", ":")))
 
 
 def cmd_image(tag: str):
+    images = load_images()
+
+    # Exact base-tag match → moving-only publish (no semver).
+    for img in images:
+        if img["base_tag"] == tag:
+            print(f"dir={shlex.quote(img['dir'])}")
+            print(f"base_tag={shlex.quote(img['base_tag'])}")
+            print(f"semver=''")
+            print(f"context={shlex.quote(img['context'])}")
+            print(f"dockerfile={shlex.quote(img['dockerfile'])}")
+            print(f"target={shlex.quote(img['target'])}")
+            print(f"build_args={shlex.quote(img['build_args'])}")
+            print(f"addons={shlex.quote(img['addons'])}")
+            return
+
     match = SEMVER_RE.match(tag)
     if not match:
+        valid = ", ".join(img["base_tag"] for img in images)
         sys.exit(
-            f"error: tag '{tag}' is not of the form <os>-<version>-<semver> "
-            f"(e.g. ubuntu-24.04-2.1.0 or ubuntu-24.04-main)"
+            f"error: tag '{tag}' is not a known base tag and is not of the form "
+            f"<os>-<version>-<semver> (e.g. ubuntu-24.04 or ubuntu-24.04-2.1.0). "
+            f"Known base tags: {valid}"
         )
     prefix = match.group("prefix")
     semver = match.group("semver")
 
-    for img in load_images():
+    for img in images:
         if img["base_tag"] == prefix:
             print(f"dir={shlex.quote(img['dir'])}")
             print(f"base_tag={shlex.quote(img['base_tag'])}")
@@ -122,7 +150,7 @@ def cmd_image(tag: str):
             print(f"addons={shlex.quote(img['addons'])}")
             return
 
-    valid = ", ".join(img["base_tag"] for img in load_images())
+    valid = ", ".join(img["base_tag"] for img in images)
     sys.exit(
         f"error: no image matches tag prefix '{prefix}'. "
         f"Known images: {valid}"
@@ -134,10 +162,10 @@ def main(argv):
         cmd_all()
     elif len(argv) >= 3 and argv[1] == "image":
         cmd_image(argv[2])
-    elif len(argv) >= 3 and argv[1] == "publish-matrix":
-        cmd_publish_matrix(argv[2])
+    elif len(argv) >= 2 and argv[1] == "publish-matrix":
+        cmd_publish_matrix(argv[2] if len(argv) >= 3 else None)
     else:
-        sys.exit(f"usage: {argv[0]} all | image <tag> | publish-matrix <date>")
+        sys.exit(f"usage: {argv[0]} all | image <tag> | publish-matrix [<semver>]")
 
 
 if __name__ == "__main__":

--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -2,15 +2,15 @@
 #
 # Build and push one image (base + all its add-ons) to a registry.
 #
-# Used by both publish.yml (GHCR) and publish-nexus.yml (Nexus). The base image
-# is pushed under a moving tag (<os>-<version>) and an immutable tag
-# (<os>-<version>-<semver>). Each add-on is a build STAGE (--target) in the same
-# Dockerfile and is pushed under its own moving + immutable tags; shared layers
-# come from the build cache, so the base is effectively built only once.
+# The base image is always pushed under the moving tag (<os>-<version>).
+# When TAG includes a semver suffix (<os>-<version>-<semver>), an additional
+# immutable tag is pushed alongside it. Each add-on is a build STAGE (--target)
+# in the same Dockerfile and follows the same moving/immutable pattern; shared
+# layers come from the build cache, so the base is effectively built only once.
 #
 # Required environment variables:
 #   REGISTRY  Image repository, e.g. ghcr.io/openmodelica/build-deps
-#   TAG       Release tag, e.g. ubuntu-24.04-2.1.0
+#   TAG       Base tag (e.g. ubuntu-24.04) or release tag (e.g. ubuntu-24.04-2.1.0)
 #   SIGN      "true" to cosign-sign every pushed tag (keyless OIDC), else "false"
 set -euo pipefail
 
@@ -21,26 +21,28 @@ SIGN="${SIGN:-false}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Resolve the tag to base_tag / semver / context / dockerfile / target /
-# build_args / addons.
+# build_args / addons.  semver is empty for moving-only publishes.
 eval "$(python3 "${SCRIPT_DIR}/matrix.py" image "${TAG}")"
 
 PUSHED_TAGS=()
 
 build_and_push() {
-  # $1 = moving tag, $2 = immutable tag, remaining args go to `docker buildx`.
+  # $1 = moving tag, $2 = immutable tag (empty → skip), remaining args go to `docker buildx`.
   local moving="$1" immutable="$2"
   shift 2
+  local tag_args=(--tag "${REGISTRY}:${moving}")
+  [[ -n "${immutable}" ]] && tag_args+=(--tag "${REGISTRY}:${immutable}")
   echo "::group::Building ${moving}"
   docker buildx build \
     --pull \
     --file "${dockerfile}" \
-    --tag "${REGISTRY}:${moving}" \
-    --tag "${REGISTRY}:${immutable}" \
+    "${tag_args[@]}" \
     --push \
     "$@" \
     "${context}"
   echo "::endgroup::"
-  PUSHED_TAGS+=("${REGISTRY}:${moving}" "${REGISTRY}:${immutable}")
+  PUSHED_TAGS+=("${REGISTRY}:${moving}")
+  [[ -n "${immutable}" ]] && PUSHED_TAGS+=("${REGISTRY}:${immutable}")
 }
 
 # Common build-args (e.g. UBUNTU_VERSION) apply to every stage.
@@ -52,12 +54,12 @@ done
 # 1. Base image: the image's `target` stage (or the final stage).
 base_target_arg=()
 [ -n "${target}" ] && base_target_arg=(--target "${target}")
-build_and_push "${base_tag}" "${base_tag}-${semver}" \
+build_and_push "${base_tag}" "${semver:+${base_tag}-${semver}}" \
   "${common_args[@]}" "${base_target_arg[@]}"
 
 # 2. Add-ons: each is a --target stage in the same Dockerfile.
 for addon in ${addons}; do
-  build_and_push "${base_tag}-${addon}" "${base_tag}-${addon}-${semver}" \
+  build_and_push "${base_tag}-${addon}" "${semver:+${base_tag}-${addon}-${semver}}" \
     "${common_args[@]}" --target "${addon}"
 done
 

--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -37,6 +37,7 @@ build_and_push() {
     --pull \
     --file "${dockerfile}" \
     "${tag_args[@]}" \
+    --cache-from "type=gha,scope=${moving}" \
     --push \
     "$@" \
     "${context}"

--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -67,7 +67,7 @@ done
 if [ "${SIGN}" = "true" ]; then
   for image in "${PUSHED_TAGS[@]}"; do
     echo "Signing ${image}"
-    cosign sign --yes "${image}"
+    cosign sign --yes --registry-referrers-mode=oci-1-1 "${image}"
   done
 fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,36 +115,7 @@ jobs:
           TARGET: ${{ matrix.image.target }}
           BUILD_ARGS: ${{ matrix.image.build_args }}
           ADDONS: ${{ matrix.image.addons }}
-        run: |
-          set -euo pipefail
-
-          # Common build-args (e.g. UBUNTU_VERSION) apply to every stage.
-          common_args=()
-          for kv in ${BUILD_ARGS}; do common_args+=(--build-arg "${kv}"); done
-
-          # Base image: the image's `target` stage (or the final stage).
-          base_target_arg=()
-          [ -n "${TARGET}" ] && base_target_arg=(--target "${TARGET}")
-          echo "::group::Building base ${BASE_TAG}"
-          docker buildx build \
-            --file "${DOCKERFILE}" \
-            "${common_args[@]}" "${base_target_arg[@]}" \
-            --tag "local/build-deps:${BASE_TAG}" \
-            --load \
-            "${CONTEXT}"
-          echo "::endgroup::"
-
-          # Add-ons: each is a --target stage in the same Dockerfile.
-          for addon in ${ADDONS}; do
-            echo "::group::Building add-on ${addon}"
-            docker buildx build \
-              --file "${DOCKERFILE}" \
-              "${common_args[@]}" --target "${addon}" \
-              --tag "local/build-deps:${BASE_TAG}-${addon}" \
-              --load \
-              "${CONTEXT}"
-            echo "::endgroup::"
-          done
+        run: ./.ci/build.sh
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,20 +6,15 @@ name: Build, Release & Publish
 #   discover ─▶ build (all images, no push)
 #                 └─▶ release (tag only) ─▶ publish-ghcr + publish-nexus
 #
-# A single repo-wide semver tag (e.g. v2.1.0) releases ALL images at once.
-# The per-image Docker tags (e.g. ubuntu-24.04-2.1.0) are synthesized from it.
-#
 # Triggers:
-#   schedule        Weekly rolling rebuild (Sunday night → Monday 03:30 UTC).
-#                   Publishes every image with a date-based immutable tag
-#                   (YYYY.MM.DD) in addition to the moving tag, without creating
-#                   a GitHub Release.
-#   push tag        Full release: GitHub Release + immutable semver tags for
-#                   all images. Tag must be of the form v<MAJOR>.<MINOR>.<PATCH>.
-#   push main       Publishes every image with a moving `-main` tag.
-#   workflow_dispatch Re-publish on demand: global tag (e.g. v2.1.0) rebuilds
-#                   all images; a single image tag (e.g. ubuntu-24.04-2.1.0)
-#                   rebuilds just that image.
+#   push main         Publishes every image with the moving tag (<os>-<version>).
+#   schedule          Weekly rolling rebuild — republishes the moving tags.
+#   push tag          Full release: GitHub Release + immutable semver tags for
+#                     all images. Tag must be of the form v<MAJOR>.<MINOR>.<PATCH>.
+#   workflow_dispatch Re-publish on demand. Leave the tag input empty to rebuild
+#                     all moving tags; pass a global tag (e.g. v2.1.0) to rebuild
+#                     all images with immutable tags; pass a single image tag
+#                     (e.g. ubuntu-24.04-2.1.0) to rebuild just that image.
 
 on:
   schedule:
@@ -35,8 +30,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Version to (re)publish: global tag (e.g. v2.1.0) rebuilds all images; single image tag (e.g. ubuntu-24.04-2.1.0) rebuilds one'
-        required: true
+        description: 'Optional: version to (re)publish. Empty = rebuild all moving tags. Global tag (e.g. v2.1.0) = all images with immutable tags. Single image tag (e.g. ubuntu-24.04-2.1.0) = one image with immutable tag.'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -69,11 +65,12 @@ jobs:
         run: |
           case "${EVENT_NAME}" in
             schedule)
-              DATE=$(date +%Y.%m.%d)
-              echo "matrix=$(python3 .ci/matrix.py publish-matrix "${DATE}")" >> "$GITHUB_OUTPUT"
+              echo "matrix=$(python3 .ci/matrix.py publish-matrix)" >> "$GITHUB_OUTPUT"
               ;;
             workflow_dispatch)
-              if [[ "${INPUT_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              if [[ -z "${INPUT_TAG}" ]]; then
+                echo "matrix=$(python3 .ci/matrix.py publish-matrix)" >> "$GITHUB_OUTPUT"
+              elif [[ "${INPUT_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                 echo "matrix=$(python3 .ci/matrix.py publish-matrix "${INPUT_TAG#v}")" >> "$GITHUB_OUTPUT"
               else
                 python3 .ci/matrix.py image "${INPUT_TAG}" > /dev/null
@@ -84,7 +81,7 @@ jobs:
               if [[ "${GH_REF}" == refs/tags/v* ]]; then
                 echo "matrix=$(python3 .ci/matrix.py publish-matrix "${GH_REF_NAME#v}")" >> "$GITHUB_OUTPUT"
               elif [[ "${GH_REF}" == refs/heads/main ]]; then
-                echo "matrix=$(python3 .ci/matrix.py publish-matrix main)" >> "$GITHUB_OUTPUT"
+                echo "matrix=$(python3 .ci/matrix.py publish-matrix)" >> "$GITHUB_OUTPUT"
               else
                 echo 'matrix=[]' >> "$GITHUB_OUTPUT"
               fi
@@ -231,9 +228,11 @@ jobs:
           eval "$(python .ci/matrix.py image "${TAG}")"
           CERT_ID="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/build.yml@${GITHUB_REF}"
           CERT_ISSUER="https://token.actions.githubusercontent.com"
-          tags=("${base_tag}" "${base_tag}-${semver}")
+          tags=("${base_tag}")
+          [[ -n "${semver}" ]] && tags+=("${base_tag}-${semver}")
           for addon in ${addons}; do
-            tags+=("${base_tag}-${addon}" "${base_tag}-${addon}-${semver}")
+            tags+=("${base_tag}-${addon}")
+            [[ -n "${semver}" ]] && tags+=("${base_tag}-${addon}-${semver}")
           done
           for t in "${tags[@]}"; do
             echo "Verifying ${REGISTRY}:${t}"

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ discover ─▶ build (all images, no push)
 - **publish-ghcr / publish-nexus** — build and push (and on GHCR **sign**) the
   images to GHCR and Nexus. Moving tags (`<os>-<version>`) are updated on every
   push to `main`, the weekly schedule, and `workflow_dispatch`. Immutable tags
-  (`<os>-<version>-<semver>`) are pushed only on a release tag.
+  (`<os>-<version>-<semver>`) are pushed on a release tag, and can also be republished via `workflow_dispatch` when a global `v<semver>` is supplied.
 
 ## Releasing a new image version
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,12 @@ matrix entry).
 One image repository per registry; OS, version and variant are encoded in the
 **tag**:
 
-| Tag                           | Mutable?  | Meaning                                                  |
-| ----------------------------- | --------- | -------------------------------------------------------- |
-| `ubuntu-24.04`                | moving    | Latest base image for Ubuntu 24.04                       |
-| `ubuntu-24.04-2.1.0`          | immutable | Pinned base, synthesized from git tag `v2.1.0`           |
-| `ubuntu-24.04-cmake-4`        | moving    | Latest CMake 4 add-on on the 24.04 base                  |
-| `ubuntu-24.04-cmake-4-2.1.0`  | immutable | Pinned add-on, synthesized from git tag `v2.1.0`         |
-| `ubuntu-24.04-main`           | moving    | Latest build from the `main` branch                      |
+| Tag                           | Mutable?  | Meaning                                               |
+| ----------------------------- | --------- | ----------------------------------------------------- |
+| `ubuntu-24.04`                | moving    | Latest base image for Ubuntu 24.04                    |
+| `ubuntu-24.04-2.1.0`          | immutable | Pinned base, synthesized from git tag `v2.1.0`        |
+| `ubuntu-24.04-cmake-4`        | moving    | Latest CMake 4 add-on on the 24.04 base               |
+| `ubuntu-24.04-cmake-4-2.1.0`  | immutable | Pinned add-on, synthesized from git tag `v2.1.0`      |
 
 Releasing is done by pushing a single repo-wide git tag `v<MAJOR>.<MINOR>.<PATCH>`
 (e.g. `v2.1.0`). CI synthesizes the per-image immutable Docker tags from it and
@@ -129,10 +128,10 @@ discover ─▶ build (all images, no push)
 - **build** — on every push/PR to `main` (and as the gate before release),
   builds every base + add-on declared in `.ci/matrix.yml` (no push).
 - **release** — on an repo-wide release tag, creates/updates the GitHub Release.
-- **publish-ghcr / publish-nexus** — build, push (and on GHCR **sign**) the
-  tagged image (base + add-ons) to GHCR and Nexus. Triggered by a release tag,
-  a push to `main` (tags ending in `-main`), the weekly schedule, or
-  `workflow_dispatch` with a `tag` input to re-publish on demand.
+- **publish-ghcr / publish-nexus** — build and push (and on GHCR **sign**) the
+  images to GHCR and Nexus. Moving tags (`<os>-<version>`) are updated on every
+  push to `main`, the weekly schedule, and `workflow_dispatch`. Immutable tags
+  (`<os>-<version>-<semver>`) are pushed only on a release tag.
 
 ## Releasing a new image version
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ main
 └── .ci/
     ├── matrix.yml          # source of truth: which images exist
     ├── matrix.py           # matrix.yml -> CI matrix / tag lookup
-    └── publish.sh          # build + push one image (base + add-ons)
+    ├── build.sh            # build one image (base + add-ons), write GHA cache
+    └── publish.sh          # restore GHA cache, push + sign one image
 ```
 
 - **Base image** — one per OS/OS-version. Contains everything needed to build

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,11 @@
 # Releasing a new image version
 
-A "release" publishes **one image** — a base image and *all* of its add-ons —
-under both a moving and an immutable tag, to GHCR and Nexus. Releases are
-driven entirely by **git tags**; you never push images by hand.
+A "release" publishes **every image** — each base image and *all* of its
+add-ons — under both a moving and an immutable tag, to GHCR and Nexus.
+Releases are driven entirely by **git tags**; you never push images by hand.
 
-> TL;DR — merge your change to `main`, then push a tag
-> `<os>-<version>-<semver>` (e.g. `ubuntu-24.04-2.1.0`). CI does the rest.
+> TL;DR — merge your change to `main`, then push a git tag
+> `v<semver>` (e.g. `v2.1.0`). CI does the rest.
 
 ## The tag grammar
 
@@ -25,11 +25,11 @@ The pair `<os>-<os-version>` must match an entry in
 
 ### What gets published
 
-For tag `ubuntu-24.04-2.1.0` the publish workflows build and push:
+For git tag `v2.1.0` the publish workflows build and push:
 
-| Image | Moving tag | Immutable tag |
-| --- | --- | --- |
-| base | `ubuntu-24.04` | `ubuntu-24.04-2.1.0` |
+| Image            | Moving tag             | Immutable tag                |
+| ---------------- | ---------------------- | ---------------------------- |
+| base             | `ubuntu-24.04`         | `ubuntu-24.04-2.1.0`         |
 | add-on `cmake-4` | `ubuntu-24.04-cmake-4` | `ubuntu-24.04-cmake-4-2.1.0` |
 
 to both `ghcr.io/openmodelica/build-deps` (signed with cosign) and
@@ -39,7 +39,7 @@ consistent and shared layers come from the build cache.
 
 ## Choosing the next semver
 
-Bump relative to the last tag **for that image** (`git tag --list '<os>-<version>-*'`):
+Bump relative to the last release tag (`git tag --list 'v*'`):
 
 - **PATCH** (`2.1.0 → 2.1.1`) — rebuild for upstream package updates / security
   fixes, no intended behavior change.
@@ -47,8 +47,8 @@ Bump relative to the last tag **for that image** (`git tag --list '<os>-<version
 - **MAJOR** (`2.1.0 → 3.0.0`) — removed/renamed something consumers rely on, or
   a base OS bump that changes the toolchain.
 
-Each image has its **own** semver line; bumping `ubuntu-24.04` does not affect
-`debian-13`.
+One git tag releases **all** images at once; there is a single shared semver
+for the whole repository.
 
 ## Step by step
 
@@ -78,8 +78,8 @@ Each image has its **own** semver line; bumping `ubuntu-24.04` does not affect
 
    ```bash
    git checkout main && git pull
-   git tag ubuntu-24.04-2.1.0
-   git push origin ubuntu-24.04-2.1.0
+   git tag v2.1.0
+   git push origin v2.1.0
    ```
 
 5. **CI publishes automatically.** Pushing the tag runs the single
@@ -92,10 +92,16 @@ Each image has its **own** semver line; bumping `ubuntu-24.04` does not affect
 ## Re-running a publish without a new tag
 
 Use the **workflow_dispatch** trigger on
-[build.yml](./.github/workflows/build.yml) and pass the existing tag (e.g.
-`ubuntu-24.04-2.1.0`). The `publish-ghcr` / `publish-nexus` jobs rebuild and
-re-push the same tags (the release step is skipped) — handy after a transient
-failure.
+[build.yml](./.github/workflows/build.yml):
+
+- **Leave the tag field empty** — rebuilds and re-pushes all moving tags
+  (`<os>-<version>`). Handy after a transient registry failure or to force a
+  fresh rebuild without cutting a new release.
+- **Pass a global tag** (e.g. `v2.1.0`) — re-publishes every image with both
+  the moving and the immutable tags for that version (the release step is
+  skipped).
+- **Pass a single image tag** (e.g. `ubuntu-24.04-2.1.0`) — re-publishes
+  only that one image with its moving and immutable tags.
 
 ## Adding a brand-new image
 
@@ -105,7 +111,7 @@ failure.
    adds `dockerfile: ubuntu/Dockerfile`, `target: full` and
    `build_args: { UBUNTU_VERSION: "<ver>" }`.
 2. Add the image to [.ci/matrix.yml](./.ci/matrix.yml).
-3. PR → merge → release as above with `<os>-<version>-1.0.0`.
+3. PR → merge → release as above with `v1.0.0`.
 
 ## Adding an add-on
 


### PR DESCRIPTION
## Issue

* The `publish-ghcr` and `publish-nexus` jobs are rebuilding all images from scratch. This is very slow for the rust image (around 30 minutes).
* Cosign is creating a bunch of `sha256:` tags and pushing them.
* `-main` tag is redundant. Only use one rolling tag `<os>-<os-version>` (updated on every commit to main / every Monday via scheduled build) and one immutable tag `<os>-<os-version>-<semver>` versioned with git tags / releases.