### PR TITLE
apt: add clang + llvm-dev to the full image for OpenModelica LLVM builds

### DIFF
--- a/apt/Dockerfile
+++ b/apt/Dockerfile
@@ -168,7 +168,6 @@ ARG COMMON_PKGS="\
     bibtex2html \
     bison \
     ccache \
-    clang \
     clang-tools \
     devscripts \
     docker.io \

--- a/apt/Dockerfile
+++ b/apt/Dockerfile
@@ -168,6 +168,7 @@ ARG COMMON_PKGS="\
     bibtex2html \
     bison \
     ccache \
+    clang \
     clang-tools \
     devscripts \
     docker.io \
@@ -180,6 +181,8 @@ ARG COMMON_PKGS="\
     latexmk \
     libcurl4-gnutls-dev \
     libmldbm-perl \
+    llvm \
+    llvm-dev \
     locales \
     ocl-icd-opencl-dev \
     opencl-headers \


### PR DESCRIPTION
## Summary

Adds `clang`, `llvm`, and `llvm-dev` to `COMMON_PKGS` in `apt/Dockerfile` so the published `build-deps:*-full` images ship the LLVM toolchain out of the box.

## Motivation

The OpenModelica `revive-llvm-jit` PR (#15890) and downstream LLVM work want `-DOM_OMC_ENABLE_LLVM=ON` to be reachable from CI without further provisioning. Today the `full` image has neither `clang` nor `llvm-dev`, so CMake's `find_package(LLVM 18 CONFIG …)` fails on the base image and any LLVM-enabled build has to install these itself.

## What CMake actually needs

`OMCompiler/Compiler/runtime/CMakeLists.txt:147-171` requires:

- LLVM ≥ 16 (asserted at line 154)
- `LLVMConfig.cmake` (provided by `llvm-N-dev`)
- Components: `core orcjit mcjit executionengine transformutils ipo support irreader bitwriter native nativecodegen`
- `clang` + `llvm-link` reachable via `LLVM_TOOLS_BINARY_DIR` (used by `EXT_LLVM.compileModelToBitcode` at simulate time to lower model C to bitcode)

The `llvm`, `llvm-dev`, `clang` meta-packages pull in the distro-default LLVM major with all of the above.

## Distro coverage

The meta-packages resolve to whatever ships natively; no third-party apt repo is added. Consequences per image in `.ci/matrix.yml`:

| image        | LLVM major | `OM_OMC_ENABLE_LLVM=ON` usable? |
|--------------|:----------:|:-------------------------------:|
| ubuntu 26.04 | 20         | yes                             |
| ubuntu 24.04 | 18         | yes                             |
| ubuntu 22.04 | 14         | no (CMake refuses at line 154)  |
| debian 13    | 19         | yes                             |
| debian 12    | 14         | no (CMake refuses at line 154)  |

The default OpenModelica build (LLVM off) is unaffected. On the two older distros, an LLVM-on build fails with a clear "needs LLVM >= 16" message rather than being silently degraded, which is the right behavior. If a follow-up wants LLVM ≥ 16 on Jammy or Bookworm, adding `apt.llvm.org` in a separate conditional `RUN` is the natural next step; that is out of scope for this PR.

## Image size impact

`llvm-N-dev` and the LLVM shared libs are large (~500 MB on Ubuntu 24.04). The `full` image already carries Qt6, TeX Live, and the OpenCL stack; the delta is meaningful but not disproportionate for a base image whose purpose is "everything needed to build OpenModelica."

## Test plan

- [ ] `docker build --target full --build-arg DISTRO=ubuntu --build-arg VERSION=24.04 --tag build-deps:ubuntu-24.04 apt` succeeds.
- [ ] Inside that image, `dpkg -l | grep -E 'llvm-|clang'` shows `llvm-18-dev` and `clang-18` (or the distro-default equivalent).
- [ ] `apt list --installed 2>/dev/null | grep -q llvm-18-dev`.
- [ ] Inside that image, cloning OpenModelica `revive-llvm-jit` and configuring with `-DOM_OMC_ENABLE_LLVM=ON -DOM_OMC_ENABLE_LLVM_JIT=ON` finds LLVM ≥ 16.
- [ ] `docker build --target full --build-arg DISTRO=ubuntu --build-arg VERSION=22.04 --tag build-deps:ubuntu-22.04 apt` still succeeds (older LLVM installed; no build regression on the default image, only `OM_OMC_ENABLE_LLVM=ON` would refuse there).

Refs OpenModelica/OpenModelica#15890