### PR TITLE
[CI] Free disc space, fix signing

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -74,7 +74,7 @@ done
 if [ "${SIGN}" = "true" ]; then
   for image in "${PUSHED_TAGS[@]}"; do
     echo "Signing ${image}"
-    cosign sign --yes --registry-referrers-mode=oci-1-1 "${image}"
+    COSIGN_EXPERIMENTAL=1 cosign sign --yes --registry-referrers-mode=oci-1-1 "${image}"
   done
 fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,18 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v7
 
+      # The rust add-on image is huge (Rust toolchains, xwin Windows SDK,
+      # Emscripten, three Qt installs) and overflows the runner's root disk
+      # during `docker buildx ... --load`. Reclaim ~20 GB of pre-installed
+      # bloat first. Only the rust-bearing image needs it.
+      - name: Free up disk space
+        if: contains(matrix.image.addons, 'rust')
+        uses: endersonmenezes/free-disk-space@v3.2.2
+        with:
+          remove_android: "true"
+          remove_dotnet: "true"
+          remove_haskell: "true"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -172,6 +184,16 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v7
 
+      # Only ubuntu-26.04 carries the rust add-on, which overflows the
+      # runner's root disk during build+push. Reclaim ~20 GB first.
+      - name: Free up disk space
+        if: contains(matrix.image.tag, 'ubuntu-26.04')
+        uses: endersonmenezes/free-disk-space@v3.2.2
+        with:
+          remove_android: "true"
+          remove_dotnet: "true"
+          remove_haskell: "true"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -239,6 +261,16 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
+
+      # Only ubuntu-26.04 carries the rust add-on, which overflows the
+      # runner's root disk during build+push. Reclaim ~20 GB first.
+      - name: Free up disk space
+        if: contains(matrix.image.tag, 'ubuntu-26.04')
+        uses: endersonmenezes/free-disk-space@v3.2.2
+        with:
+          remove_android: "true"
+          remove_dotnet: "true"
+          remove_haskell: "true"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Issue

From time to time we run out of disc space and the signing step of CI is failing.

```
Signing ghcr.io/openmodelica/build-deps:ubuntu-24.04
Error: invalid argument "oci-1-1" for "--registry-referrers-mode" flag: in order to use  mode "oci-1-1", you must set COSIGN_EXPERIMENTAL=1
error during command execution: invalid argument "oci-1-1" for "--registry-referrers-mode" flag: in order to use  mode "oci-1-1", you must set COSIGN_EXPERIMENTAL=1
Error: Process completed with exit code 1.
```

## Changes

* Remove disc space on runners
* Adding `COSIGN_EXPERIMENTAL=1` to use `--registry-referrers-mode=oci-1-1`