### PR TITLE
Pinning FMPy at 0.3.29

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,12 +104,8 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v7
 
-      # The rust add-on image is huge (Rust toolchains, xwin Windows SDK,
-      # Emscripten, three Qt installs) and overflows the runner's root disk
-      # during `docker buildx ... --load`. Reclaim ~20 GB of pre-installed
-      # bloat first. Only the rust-bearing image needs it.
+      # The Dockerfile tend to be huge, free up some space on the GitHub runners
       - name: Free up disk space
-        if: contains(matrix.image.addons, 'rust')
         uses: endersonmenezes/free-disk-space@v3.2.2
         with:
           remove_android: "true"
@@ -184,10 +180,8 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v7
 
-      # Only ubuntu-26.04 carries the rust add-on, which overflows the
-      # runner's root disk during build+push. Reclaim ~20 GB first.
+      # The Dockerfile tend to be huge, free up some space on the GitHub runners
       - name: Free up disk space
-        if: contains(matrix.image.tag, 'ubuntu-26.04')
         uses: endersonmenezes/free-disk-space@v3.2.2
         with:
           remove_android: "true"
@@ -262,10 +256,8 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v7
 
-      # Only ubuntu-26.04 carries the rust add-on, which overflows the
-      # runner's root disk during build+push. Reclaim ~20 GB first.
+      # The Dockerfile tend to be huge, free up some space on the GitHub runners
       - name: Free up disk space
-        if: contains(matrix.image.tag, 'ubuntu-26.04')
         uses: endersonmenezes/free-disk-space@v3.2.2
         with:
           remove_android: "true"

--- a/apt/Dockerfile
+++ b/apt/Dockerfile
@@ -87,7 +87,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Use permalink for doc/UsersGuide/source/requirements.txt to keep builds
 # deterministic.
 RUN pip install --no-cache-dir \
-    fmpy \
+    fmpy==0.3.29 \
     junit_xml \
     lxml \
     ompython==3.6.0 \


### PR DESCRIPTION
* There is a regression in FMPy 0.3.30, see https://github.com/CATIA-Systems/FMPy/issues/882.