### PR TITLE
OMSimulator add-on

### DIFF
--- a/.ci/matrix.yml
+++ b/.ci/matrix.yml
@@ -39,6 +39,7 @@ images:
     addons:
       - rust
       - debug
+      - omsimulator
 
   - os: ubuntu
     version: "24.04"
@@ -51,6 +52,7 @@ images:
     addons:
       - cmake-4
       - debug
+      - omsimulator
 
   - os: ubuntu
     version: "22.04"
@@ -62,6 +64,7 @@ images:
       VERSION: "22.04"
     addons:
       - debug
+      - omsimulator
 
   - os: debian
     version: "13"

--- a/README.md
+++ b/README.md
@@ -71,15 +71,15 @@ OpenModelica release needs a frozen environment it pins the **immutable** tag.
 
 ### Currently provided images
 
-| OS / version            | Base tag       | Add-ons            | Dockerfile          | Status      |
-| ----------------------- | -------------- | ------------------ | ------------------- | ----------- |
-| Ubuntu 26.04 (Resolute) | `ubuntu-26.04` | `rust`, `debug`    | `apt/Dockerfile`    | implemented |
-| Ubuntu 24.04 (Noble)    | `ubuntu-24.04` | `cmake-4`, `debug` | `apt/Dockerfile`    | implemented |
-| Ubuntu 22.04 (Jammy)    | `ubuntu-22.04` | `debug`            | `apt/Dockerfile`    | implemented |
-| Debian 13 (Trixie)      | `debian-13`    | `cmake-4`, `debug` | `apt/Dockerfile`    | implemented |
-| Debian 12 (Bookworm)    | `debian-12`    | `cmake-4`, `debug` | `apt/Dockerfile`    | implemented |
-| Fedora, AlmaLinux, RHEL | `<os>-<ver>`   | –                  | `rpm/Dockerfile`    | planned     |
-| Arch Linux (rolling)    | `arch-rolling` | –                  | `pacman/Dockerfile` | placeholder |
+| OS / version            | Base tag       | Add-ons                           | Dockerfile          | Status      |
+| ----------------------- | -------------- | --------------------------------- | ------------------- | ----------- |
+| Ubuntu 26.04 (Resolute) | `ubuntu-26.04` | `rust`, `debug`, `omsimulator`    | `apt/Dockerfile`    | implemented |
+| Ubuntu 24.04 (Noble)    | `ubuntu-24.04` | `cmake-4`, `debug`, `omsimulator` | `apt/Dockerfile`    | implemented |
+| Ubuntu 22.04 (Jammy)    | `ubuntu-22.04` | `debug`, `omsimulator`            | `apt/Dockerfile`    | implemented |
+| Debian 13 (Trixie)      | `debian-13`    | `cmake-4`, `debug`                | `apt/Dockerfile`    | implemented |
+| Debian 12 (Bookworm)    | `debian-12`    | `cmake-4`, `debug`                | `apt/Dockerfile`    | implemented |
+| Fedora, AlmaLinux, RHEL | `<os>-<ver>`   | –                                 | `rpm/Dockerfile`    | planned     |
+| Arch Linux (rolling)    | `arch-rolling` | –                                 | `pacman/Dockerfile` | placeholder |
 
 ## Build locally
 

--- a/apt/Dockerfile
+++ b/apt/Dockerfile
@@ -11,6 +11,7 @@
 #   cmake-4  ADD-ON: full + CMake 4 from the official Kitware release
 #   debug    ADD-ON: full + GDB, Valgrind, and other debugging tools
 #   rust     ADD-ON: full + Rust toolchain + Emscripten + Qt for Wasm (Ubuntu only)
+#   omsimulator ADD-ON: full + X11 dev libs for the OMSimulator build
 #
 # Build the base image (the `full` target):
 #   docker build --target full --build-arg DISTRO=ubuntu --build-arg VERSION=26.04 \
@@ -330,5 +331,21 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
     libclang-rt-dev-wasm32 \
     wine \
     mold \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# ── OMSimulator add-on: full + X11 dev libs OMSimulator's GUI links against ───
+# Mirrors OMSimulator/.CI/cache/Dockerfile. The AddressSanitizer runtime is not
+# installed explicitly; the gcc/g++ toolchain pulls in its matching libasan when
+# building with -fsanitize=address. Built with `--target omsimulator`.
+FROM full AS omsimulator
+LABEL org.opencontainers.image.description="OMSimulator build-deps"
+RUN export DEBIAN_FRONTEND=noninteractive && \
+  apt-get update \
+  && apt-get install -qy \
+    libxcursor-dev \
+    libxi-dev \
+    libxinerama-dev \
+    libxrandr-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Issue 

The Jenkins pipeline for OMSimulator is failing all the time building Docker images for testing.

## Changes

* Added OMSimulator add-on with ASAN and X11 build deps for all Ubuntu versions.