### PR TITLE
Add Alpine build-deps image with OMSimulator add-on

### DIFF
--- a/.ci/matrix.yml
+++ b/.ci/matrix.yml
@@ -91,6 +91,18 @@ images:
       - cmake-4
       - debug
 
+  # Alpine has no OpenModelica apk repo; apk/Dockerfile installs the build
+  # dependencies directly. VERSION selects the Alpine release.
+  - os: alpine
+    version: "3.22"
+    context: apk
+    dockerfile: apk/Dockerfile
+    target: full
+    build_args:
+      VERSION: "3.22"
+    addons:
+      - omsimulator
+
   # Placeholders — not implemented yet. Uncomment and flesh out once the
   # corresponding Dockerfile is real, so CI starts building them.
   #

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ than by OpenModelica version. Each image is a **base** plus optional, layered
 main
 ├── apt/
 │   └── Dockerfile          # multi-stage: all Ubuntu + Debian versions + add-ons
+├── apk/
+│   └── Dockerfile          # multi-stage: Alpine Linux + add-ons
 ├── rpm/
 │   └── Dockerfile          # planned: Fedora, AlmaLinux, Rocky Linux, RHEL
 ├── pacman/
@@ -78,6 +80,7 @@ OpenModelica release needs a frozen environment it pins the **immutable** tag.
 | Ubuntu 22.04 (Jammy)    | `ubuntu-22.04` | `debug`, `omsimulator`            | `apt/Dockerfile`    | implemented |
 | Debian 13 (Trixie)      | `debian-13`    | `cmake-4`, `debug`                | `apt/Dockerfile`    | implemented |
 | Debian 12 (Bookworm)    | `debian-12`    | `cmake-4`, `debug`                | `apt/Dockerfile`    | implemented |
+| Alpine 3.22             | `alpine-3.22`  | `omsimulator`                     | `apk/Dockerfile`    | implemented |
 | Fedora, AlmaLinux, RHEL | `<os>-<ver>`   | –                                 | `rpm/Dockerfile`    | planned     |
 | Arch Linux (rolling)    | `arch-rolling` | –                                 | `pacman/Dockerfile` | placeholder |
 
@@ -110,6 +113,26 @@ docker build --pull \
   --build-arg DISTRO=ubuntu --build-arg VERSION=24.04 \
   --tag build-deps:ubuntu-24.04-cmake-4 \
   apt
+```
+
+**Alpine** uses the separate [apk/Dockerfile][apk-dockerfile] context. Alpine has
+no OpenModelica apk repo, so the build dependencies are installed directly; the
+only build-arg is `VERSION` (the Alpine release):
+
+```bash
+# Base image (the `full` stage)
+docker build --pull --no-cache \
+  --target full \
+  --build-arg VERSION=3.22 \
+  --tag build-deps:alpine-3.22 \
+  apk
+
+# OMSimulator add-on (reuses the base's cached layers)
+docker build --pull \
+  --target omsimulator \
+  --build-arg VERSION=3.22 \
+  --tag build-deps:alpine-3.22-omsimulator \
+  apk
 ```
 
 > The values to pass (`context`, `--file`, `--target`, `--build-arg`) for any
@@ -150,6 +173,7 @@ See [LICENSE.md][license-md].
 [jenkins]: https://test.openmodelica.org/jenkins/
 [matrix-yml]: ./.ci/matrix.yml
 [apt-dockerfile]: ./apt/Dockerfile
+[apk-dockerfile]: ./apk/Dockerfile
 [workflow-build-file]: ./.github/workflows/build.yml
 [releasing-md]: ./RELEASING.md
 [build-scripts]: https://github.com/OpenModelica/OpenModelicaBuildScripts

--- a/apk/Dockerfile
+++ b/apk/Dockerfile
@@ -1,0 +1,174 @@
+# Multi-stage, shared image for Alpine Linux.
+#
+# A single Dockerfile covers the supported Alpine versions; VERSION is the only
+# per-image difference. Alpine has no OpenModelica apk repository, so the build
+# dependencies are installed directly with apk (there is no `apt build-dep`
+# equivalent). Package names were resolved against the Alpine main/community
+# repositories.
+#
+# Stages / build targets:
+#   base        OpenModelica build dependencies (toolchain + core libraries)
+#   venv        Python virtualenv at /opt/venv, built in isolation and copied later
+#   full        the published BASE image: base + Qt6 + OpenSceneGraph + python venv
+#   omsimulator ADD-ON: full + X11/mesa dev libs for the OMSimulator build
+#
+# Build the base image (the `full` target):
+#   docker build --target full --build-arg VERSION=3.22 \
+#     --tag build-deps:alpine-3.22 apk
+#
+# Build the OMSimulator add-on image (the `omsimulator` target):
+#   docker build --target omsimulator --build-arg VERSION=3.22 \
+#     --tag build-deps:alpine-3.22-omsimulator apk
+#
+# CI passes VERSION and the --target per image from .ci/matrix.yml.
+
+ARG VERSION=3.22
+
+# ── base: OpenModelica build dependencies only ────────────────────────────────
+FROM alpine:${VERSION} AS base
+ARG VERSION
+
+# Image / OCI metadata (inherited by the stages built FROM this one)
+LABEL maintainer="AnHeuermann" \
+      description="OpenModelica build-deps Docker Image" \
+      organization="OpenModelica"
+
+LABEL org.opencontainers.image.vendor="OpenModelica" \
+      org.opencontainers.image.authors="AnHeuermann" \
+      org.opencontainers.image.description="OpenModelica build-deps base image" \
+      org.opencontainers.image.source="https://github.com/OpenModelica/build-deps" \
+      org.opencontainers.image.license="MIT"
+
+ENV SHELL=/bin/bash \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+# Qt6, Boost, LAPACK/BLAS, HDF5 and OpenSceneGraph live in the community repo,
+# so make sure both main and community are enabled and pinned to this version.
+RUN printf '%s\n' \
+      "https://dl-cdn.alpinelinux.org/alpine/v${VERSION}/main" \
+      "https://dl-cdn.alpinelinux.org/alpine/v${VERSION}/community" \
+      > /etc/apk/repositories \
+  && apk update && apk upgrade
+
+# Core toolchain and libraries needed to build the OpenModelica compiler.
+# Mirrors OMCompiler/README.Linux.md §1.2 (autotools/cmake, g++/gfortran, clang,
+# LAPACK/BLAS, hdf5, hwloc, boost, libcurl, expat, ncurses/readline, …).
+RUN apk add --no-cache \
+    autoconf \
+    automake \
+    bash \
+    bison \
+    boost-dev \
+    build-base \
+    bzip2-dev \
+    ccache \
+    clang \
+    cmake \
+    coreutils \
+    curl \
+    curl-dev \
+    expat-dev \
+    flex \
+    g++ \
+    gfortran \
+    git \
+    hdf5-dev \
+    hwloc-dev \
+    lapack-dev \
+    libtool \
+    libxml2-dev \
+    libxslt-dev \
+    linux-headers \
+    make \
+    musl-dev \
+    ncurses-dev \
+    openblas-dev \
+    openjdk17-jre-headless \
+    openmp-dev \
+    openssl-dev \
+    patch \
+    pkgconf \
+    readline-dev \
+    tar \
+    unzip \
+    util-linux \
+    wget \
+    xz \
+    zip \
+    zlib-dev
+
+# CI mounts fresh named volumes under /cache; Docker seeds an empty volume with
+# the mount point's image permissions, so create them world-writable for the
+# non-root Jenkins uid (emscripten/sccache/runtest/omlibrary caches).
+RUN mkdir -p /cache/emscripten /cache/sccache /cache/runtest /cache/omlibrary \
+  && chmod -R 0777 /cache
+
+# ── venv: Python tooling, isolated so it caches independently ─────────────────
+# Built once and copied into `full`. Uses the same python3 as `full` (same
+# base image), so the relocated /opt/venv works there unchanged.
+FROM base AS venv
+RUN apk add --no-cache python3 py3-pip
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+# Use permalink for doc/UsersGuide/source/requirements.txt to keep builds
+# deterministic.
+RUN pip install --no-cache-dir \
+    fmpy==0.3.29 \
+    junit_xml \
+    lxml \
+    ompython==3.6.0 \
+    PyGithub \
+    simplejson \
+    svgwrite \
+  && pip install --no-cache-dir -r \
+    https://raw.githubusercontent.com/OpenModelica/OpenModelica/9c0dc9a8ab50ba652109584cb3fecaef86640b66/doc/UsersGuide/source/requirements.txt
+
+# ── full: the published base image ────────────────────────────────────────────
+#   - Qt6 for OMEdit (base + the modules OpenModelica links against)
+#   - OpenSceneGraph for the OMEdit 3D animation view
+#   - doc generators (doxygen, graphviz) and a few build utilities
+FROM base AS full
+
+# Package lists as build-args, so they are easy to read and to override.
+#   - QT_PKGS   : Qt6 modules OMEdit builds against
+#   - EXTRA_PKGS: OpenSceneGraph, doc generators and misc build utilities
+ARG QT_PKGS="\
+    qt6-qt5compat-dev \
+    qt6-qtbase-dev \
+    qt6-qtdeclarative-dev \
+    qt6-qthttpserver-dev \
+    qt6-qtquick3d-dev \
+    qt6-qtscxml-dev \
+    qt6-qtserialport-dev \
+    qt6-qtshadertools-dev \
+    qt6-qtsvg-dev \
+    qt6-qttools-dev \
+    qt6-qtwebengine-dev \
+    qt6-qtwebsockets-dev"
+ARG EXTRA_PKGS="\
+    doxygen \
+    gnuplot \
+    graphviz \
+    jq \
+    openscenegraph-dev"
+RUN apk add --no-cache ${QT_PKGS} ${EXTRA_PKGS}
+
+# Pull in the venv built in its own stage instead of rebuilding it here.
+COPY --from=venv /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# ── OMSimulator add-on: full + X11/mesa dev libs OMSimulator links against ────
+# Mirrors OMSimulator/.CI/alpine/Dockerfile plus the GLFW/GUI X11 dependencies.
+# Everything else OMSimulator needs (automake, cmake, g++, git, libtool,
+# linux-headers, make, musl-dev, readline-dev, util-linux) is already in `base`,
+# so only the X11/mesa dev libraries are added here. Built with
+# `--target omsimulator`.
+FROM full AS omsimulator
+LABEL org.opencontainers.image.description="OMSimulator build-deps"
+RUN apk add --no-cache \
+    libxcursor-dev \
+    libxi-dev \
+    libxinerama-dev \
+    libxrandr-dev \
+    mesa-dev


### PR DESCRIPTION
## Changes

* Adding Alpine build-deps for OpenModelica and OMSimulator.

## Approach

Alpine has no OpenModelica apk repository, so apk/Dockerfile installs the build dependencies directly (resolved against the Alpine main/community repos) instead of via `apt build-dep`. It follows the same multi-stage layout as apt/Dockerfile:

  base        toolchain + core libraries (g++, gfortran, clang, cmake,
              LAPACK/BLAS, hdf5, hwloc, boost, JRE for the ANTLR parser,
              openmp-dev for -fopenmp, ...)
  venv        Python virtualenv at /opt/venv, copied into full
  full        base + Qt6 + OpenSceneGraph + doc generators
  omsimulator add-on: full + X11/mesa dev libs (libxcursor, libxi,
              libxinerama, libxrandr, mesa); the rest of OMSimulator's
              deps are already in base

Register alpine-3.22 in .ci/matrix.yml and document it in the README (structure tree, image table, and a build-locally section).