### PR TITLE
rpm: build-deps images for Enterprise Linux and Fedora

### DIFF
--- a/.ci/matrix.yml
+++ b/.ci/matrix.yml
@@ -103,21 +103,63 @@ images:
     addons:
       - omsimulator
 
+  # RPM-based distros — the enterprise family (AlmaLinux, Rocky Linux, RHEL) and
+  # Fedora — share rpm/Dockerfile; only DISTRO and VERSION differ. The base image
+  # is the `full` stage. EPEL/CRB, Qt5/Qt6, autoconf 2.7x, gcc-toolset and the
+  # Fedora-only deps are selected from ID/PLATFORM_ID at build time — see
+  # rpm/Dockerfile.
+  - os: almalinux
+    version: "10"
+    context: rpm
+    dockerfile: rpm/Dockerfile
+    target: full
+    build_args:
+      DISTRO: almalinux
+      VERSION: "10"
+    addons: []
+
+  - os: almalinux
+    version: "9"
+    context: rpm
+    dockerfile: rpm/Dockerfile
+    target: full
+    build_args:
+      DISTRO: almalinux
+      VERSION: "9"
+    addons: []
+
+  - os: rockylinux
+    version: "10"
+    context: rpm
+    dockerfile: rpm/Dockerfile
+    target: full
+    build_args:
+      DISTRO: rockylinux
+      VERSION: "10"
+    addons: []
+
+  - os: fedora
+    version: "44"
+    context: rpm
+    dockerfile: rpm/Dockerfile
+    target: full
+    build_args:
+      DISTRO: fedora
+      VERSION: "44"
+    addons: []
+
+  - os: fedora
+    version: "43"
+    context: rpm
+    dockerfile: rpm/Dockerfile
+    target: full
+    build_args:
+      DISTRO: fedora
+      VERSION: "43"
+    addons: []
+
   # Placeholders — not implemented yet. Uncomment and flesh out once the
   # corresponding Dockerfile is real, so CI starts building them.
-  #
-  # RPM-based distros (Fedora, AlmaLinux, Rocky Linux, RHEL) will share
-  # rpm/Dockerfile — see that file for details.
-  #
-  # - os: fedora
-  #   version: "42"
-  #   context: rpm
-  #   dockerfile: rpm/Dockerfile
-  #   target: full
-  #   build_args:
-  #     DISTRO: fedora
-  #     VERSION: "42"
-  #   addons: []
   #
   # - os: arch
   #   version: "rolling"

--- a/.ci/matrix.yml
+++ b/.ci/matrix.yml
@@ -103,7 +103,7 @@ images:
     addons:
       - omsimulator
 
-  # RPM-based distros — the enterprise family (AlmaLinux, Rocky Linux, RHEL) and
+  # RPM-based distros — the enterprise family (AlmaLinux, RHEL) and
   # Fedora — share rpm/Dockerfile; only DISTRO and VERSION differ. The base image
   # is the `full` stage. EPEL/CRB, Qt5/Qt6, autoconf 2.7x, gcc-toolset and the
   # Fedora-only deps are selected from ID/PLATFORM_ID at build time — see
@@ -126,16 +126,6 @@ images:
     build_args:
       DISTRO: almalinux
       VERSION: "9"
-    addons: []
-
-  - os: rockylinux
-    version: "10"
-    context: rpm
-    dockerfile: rpm/Dockerfile
-    target: full
-    build_args:
-      DISTRO: rockylinux
-      VERSION: "10"
     addons: []
 
   - os: fedora

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ main
 ├── apk/
 │   └── Dockerfile          # multi-stage: Alpine Linux + add-ons
 ├── rpm/
-│   └── Dockerfile          # planned: Fedora, AlmaLinux, Rocky Linux, RHEL
+│   └── Dockerfile          # multi-stage: AlmaLinux, Rocky Linux, RHEL, Fedora
 ├── pacman/
 │   └── Dockerfile          # placeholder (not implemented yet)
 └── .ci/
@@ -73,16 +73,19 @@ OpenModelica release needs a frozen environment it pins the **immutable** tag.
 
 ### Currently provided images
 
-| OS / version            | Base tag       | Add-ons                           | Dockerfile          | Status      |
-| ----------------------- | -------------- | --------------------------------- | ------------------- | ----------- |
-| Ubuntu 26.04 (Resolute) | `ubuntu-26.04` | `rust`, `debug`, `omsimulator`    | `apt/Dockerfile`    | implemented |
-| Ubuntu 24.04 (Noble)    | `ubuntu-24.04` | `cmake-4`, `debug`, `omsimulator` | `apt/Dockerfile`    | implemented |
-| Ubuntu 22.04 (Jammy)    | `ubuntu-22.04` | `debug`, `omsimulator`            | `apt/Dockerfile`    | implemented |
-| Debian 13 (Trixie)      | `debian-13`    | `cmake-4`, `debug`                | `apt/Dockerfile`    | implemented |
-| Debian 12 (Bookworm)    | `debian-12`    | `cmake-4`, `debug`                | `apt/Dockerfile`    | implemented |
-| Alpine 3.24             | `alpine-3.24`  | `omsimulator`                     | `apk/Dockerfile`    | implemented |
-| Fedora, AlmaLinux, RHEL | `<os>-<ver>`   | –                                 | `rpm/Dockerfile`    | planned     |
-| Arch Linux (rolling)    | `arch-rolling` | –                                 | `pacman/Dockerfile` | placeholder |
+| OS / version            | Base tag        | Add-ons                           | Dockerfile       |
+| ----------------------- | --------------- | --------------------------------- | ---------------- |
+| Ubuntu 26.04 (Resolute) | `ubuntu-26.04`  | `rust`, `debug`, `omsimulator`    | `apt/Dockerfile` |
+| Ubuntu 24.04 (Noble)    | `ubuntu-24.04`  | `cmake-4`, `debug`, `omsimulator` | `apt/Dockerfile` |
+| Ubuntu 22.04 (Jammy)    | `ubuntu-22.04`  | `debug`, `omsimulator`            | `apt/Dockerfile` |
+| Debian 13 (Trixie)      | `debian-13`     | `cmake-4`, `debug`                | `apt/Dockerfile` |
+| Debian 12 (Bookworm)    | `debian-12`     | `cmake-4`, `debug`                | `apt/Dockerfile` |
+| Alpine 3.24             | `alpine-3.24`   | `omsimulator`                     | `apk/Dockerfile` |
+| AlmaLinux 10            | `almalinux-10`  | –                                 | `rpm/Dockerfile` |
+| AlmaLinux 9             | `almalinux-9`   | –                                 | `rpm/Dockerfile` |
+| Rocky Linux 10          | `rockylinux-10` | –                                 | `rpm/Dockerfile` |
+| Fedora 44               | `fedora-44`     | –                                 | `rpm/Dockerfile` |
+| Fedora 43               | `fedora-43`     | –                                 | `rpm/Dockerfile` |
 
 ## Build locally
 
@@ -135,6 +138,34 @@ docker build --pull \
   apk
 ```
 
+**Enterprise Linux** (AlmaLinux, Rocky Linux, RHEL) and **Fedora** share
+[rpm/Dockerfile][rpm-dockerfile]. `DISTRO` and `VERSION` select the base image;
+EPEL/CRB, Qt5/Qt6, autoconf 2.7x and gcc-toolset are picked from `ID`/`PLATFORM_ID`
+at build time:
+
+```bash
+# AlmaLinux
+docker build --pull --no-cache \
+  --target full \
+  --build-arg DISTRO=almalinux --build-arg VERSION=10 \
+  --tag build-deps:almalinux-10 \
+  rpm
+
+# Rocky Linux
+docker build --pull --no-cache \
+  --target full \
+  --build-arg DISTRO=rockylinux --build-arg VERSION=10 \
+  --tag build-deps:rockylinux-10 \
+  rpm
+
+# Fedora
+docker build --pull --no-cache \
+  --target full \
+  --build-arg DISTRO=fedora --build-arg VERSION=44 \
+  --tag build-deps:fedora-44 \
+  rpm
+```
+
 > The values to pass (`context`, `--file`, `--target`, `--build-arg`) for any
 > image are exactly its fields in [.ci/matrix.yml][matrix-yml].
 
@@ -174,6 +205,7 @@ See [LICENSE.md][license-md].
 [matrix-yml]: ./.ci/matrix.yml
 [apt-dockerfile]: ./apt/Dockerfile
 [apk-dockerfile]: ./apk/Dockerfile
+[rpm-dockerfile]: ./rpm/Dockerfile
 [workflow-build-file]: ./.github/workflows/build.yml
 [releasing-md]: ./RELEASING.md
 [build-scripts]: https://github.com/OpenModelica/OpenModelicaBuildScripts

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ main
 ├── apk/
 │   └── Dockerfile          # multi-stage: Alpine Linux + add-ons
 ├── rpm/
-│   └── Dockerfile          # multi-stage: AlmaLinux, Rocky Linux, RHEL, Fedora
+│   └── Dockerfile          # multi-stage: AlmaLinux, RHEL, Fedora
 ├── pacman/
 │   └── Dockerfile          # placeholder (not implemented yet)
 └── .ci/
@@ -83,7 +83,6 @@ OpenModelica release needs a frozen environment it pins the **immutable** tag.
 | Alpine 3.24             | `alpine-3.24`   | `omsimulator`                     | `apk/Dockerfile` |
 | AlmaLinux 10            | `almalinux-10`  | –                                 | `rpm/Dockerfile` |
 | AlmaLinux 9             | `almalinux-9`   | –                                 | `rpm/Dockerfile` |
-| Rocky Linux 10          | `rockylinux-10` | –                                 | `rpm/Dockerfile` |
 | Fedora 44               | `fedora-44`     | –                                 | `rpm/Dockerfile` |
 | Fedora 43               | `fedora-43`     | –                                 | `rpm/Dockerfile` |
 
@@ -138,7 +137,7 @@ docker build --pull \
   apk
 ```
 
-**Enterprise Linux** (AlmaLinux, Rocky Linux, RHEL) and **Fedora** share
+**Enterprise Linux** (AlmaLinux, RHEL) and **Fedora** share
 [rpm/Dockerfile][rpm-dockerfile]. `DISTRO` and `VERSION` select the base image;
 EPEL/CRB, Qt5/Qt6, autoconf 2.7x and gcc-toolset are picked from `ID`/`PLATFORM_ID`
 at build time:
@@ -149,13 +148,6 @@ docker build --pull --no-cache \
   --target full \
   --build-arg DISTRO=almalinux --build-arg VERSION=10 \
   --tag build-deps:almalinux-10 \
-  rpm
-
-# Rocky Linux
-docker build --pull --no-cache \
-  --target full \
-  --build-arg DISTRO=rockylinux --build-arg VERSION=10 \
-  --tag build-deps:rockylinux-10 \
   rpm
 
 # Fedora

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -1,31 +1,239 @@
-# PLACEHOLDER — OpenModelica build-deps image for RPM-based distros.
+# Multi-stage, shared image for the RPM-based distros: the enterprise family
+# AlmaLinux / Rocky Linux / RHEL (all EL = Enterprise Linux, i.e. the `rhel`
+# family) and Fedora. A single Dockerfile covers EL 9, 10 and Fedora 43, 44;
+# DISTRO and VERSION are the only per-image differences, plus a handful of
+# distro-specific packages (Qt5 vs Qt6, EPEL/CRB, autoconf 2.7x, gcc-toolset,
+# omniORB) selected from ID/PLATFORM_ID at build time.
 #
-# Not implemented yet. Will follow the same layout as ../apt/Dockerfile: a
-# single multi-stage Dockerfile covering all supported versions of Fedora,
-# AlmaLinux, Rocky Linux, and RHEL, with these stages:
-#   base     OpenModelica build dependencies only (dnf builddep openmodelica)
-#   full     the published base image (build-deps:<os>-<ver>)
-#   <addon>  optional add-on stages (FROM full)
+# The build-dependency list is the translation of the OpenModelica RPM spec
+# (OpenModelicaBuildScripts/rpm/SPECS/openmodelica.spec.tpl, the `BuildRequires`)
+# and the per-distro setup in that repo's Dockerfile.rpm-el{9,10}.template and
+# Dockerfile.rpm-fc{42,43}.template (EPEL + CRB/powertools on EL only, autoconf
+# 2.7x symlinks, the qmake symlink). It is kept explicit here — like
+# apt/Dockerfile's package lists — instead of running `dnf builddep` against the
+# OpenModelica repo, so the image is self-contained and does not depend on a
+# matching source RPM being published.
 #
-# The distro and version are selected with build-args, e.g.:
-#   ARG DISTRO=fedora
-#   ARG VERSION=42
-#   FROM ${DISTRO}:${VERSION} AS base
+# Stages / build targets:
+#   base     OpenModelica build dependencies only
+#   venv     Python virtualenv at /opt/venv, built in isolation and copied later
+#   full     the published BASE image: base + common tooling + python venv
 #
-# Enterprise distros (AlmaLinux, Rocky Linux, RHEL) require EPEL and the CRB
-# repo to be enabled before dnf can resolve all build dependencies:
-#   dnf install -y epel-release
-#   dnf config-manager --set-enabled crb
-# This can be handled with a case "${ID}" block, similar to how apt/Dockerfile
-# selects Qt package sets per distro version.
+# Build the base image (the `full` target):
+#   docker build --target full --build-arg DISTRO=almalinux --build-arg VERSION=10 \
+#     --tag build-deps:almalinux-10 rpm
+#   docker build --target full --build-arg DISTRO=rockylinux --build-arg VERSION=10 \
+#     --tag build-deps:rockylinux-10 rpm
+#   docker build --target full --build-arg DISTRO=fedora --build-arg VERSION=44 \
+#     --tag build-deps:fedora-44 rpm
 #
-# To implement:
-#   1. Replace this file with a real multi-stage Dockerfile (see
-#      ../apt/Dockerfile and RELEASING.md).
-#   2. Add entries to .ci/matrix.yml
-#      (context: rpm, dockerfile: rpm/Dockerfile, target: full,
-#       build_args: { DISTRO: fedora, VERSION: "42" }).
-#   3. Open a PR; build.yml will build it.
+# RHEL: the public AlmaLinux / Rocky images are bug-for-bug EL rebuilds, so the
+# same recipe applies to a RHEL/UBI base — pass DISTRO/VERSION for a RHEL base
+# image (e.g. redhat/ubi9) that your build host is entitled to.
 #
-# Until then RPM-based images are intentionally absent from .ci/matrix.yml,
-# so CI does not try to build them.
+# CI passes DISTRO, VERSION and the --target per image from .ci/matrix.yml.
+
+ARG DISTRO=almalinux
+ARG VERSION=10
+
+# ── base: OpenModelica build dependencies only ────────────────────────────────
+FROM ${DISTRO}:${VERSION} AS base
+
+# Image / OCI metadata (inherited by the stages built FROM this one)
+LABEL maintainer="AnHeuermann" \
+      description="OpenModelica build-deps Docker Image" \
+      organization="OpenModelica"
+
+LABEL org.opencontainers.image.vendor="OpenModelica" \
+      org.opencontainers.image.authors="AnHeuermann" \
+      org.opencontainers.image.description="OpenModelica build-deps base image" \
+      org.opencontainers.image.source="https://github.com/OpenModelica/build-deps" \
+      org.opencontainers.image.license="MIT"
+
+ENV SHELL=/bin/bash \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+# Package lists as build-args, so they are easy to read and to override:
+#   - BUILD_PKGS  : build dependencies common to every distro (spec's
+#                   version-independent BuildRequires).
+#   - QT6_PKGS    : Qt6 build set for EL 9, EL 10 and Fedora. OMEdit's CMake
+#                   build needs Qt6 (the Quick3D component is effectively
+#                   Qt6-only on EL/Fedora), so everything with Qt6 available
+#                   uses it. qt6-qtbase-devel already ships /usr/bin/qmake.
+#   - QT5_PKGS    : Qt5 fallback for EL 8 only (no Qt6 in EL 8 AppStream). Note
+#                   EL 8 lacks qt5-qtquick3d, so an OMEdit build needing Quick3D
+#                   cannot be satisfied there; EL 8 is not in .ci/matrix.yml.
+#   - FEDORA_PKGS : Fedora-only BuildRequires the EL builds skip — omniORB/lpsolve
+#                   (the --with-omniORB branch, taken when rhel < 8, i.e. also on
+#                   Fedora). OMEdit's 3D animation uses Qt Quick 3D
+#                   (qt6-qtquick3d-devel, in QT6_PKGS), not OpenSceneGraph.
+# Distro-specific extras handled in the RUN case block below:
+#   - EL only : EPEL + CRB/powertools (Fedora needs neither).
+#   - EL 8/9  : autoconf 2.7x (from EPEL) symlinked as autoconf/autoreconf/…
+#   - EL 8    : gcc-toolset-11 (default gcc 8.5 is too old) + qmake -> qmake-qt5
+#   - EL 10   : nothing extra (new enough autoconf, qt6 already in QT6_PKGS)
+#   - Fedora  : new enough autoconf/gcc; qmake ships with qt6-qtbase-devel
+ARG BUILD_PKGS="\
+    automake \
+    bison \
+    boost-devel \
+    boost-static \
+    clang \
+    cmake \
+    curl-devel \
+    expat-devel \
+    flex \
+    gcc \
+    gcc-c++ \
+    gcc-gfortran \
+    gettext \
+    hdf5-devel \
+    hwloc-devel \
+    java-devel \
+    lapack-devel \
+    libffi-devel \
+    libstdc++-static \
+    libtool \
+    libuuid-devel \
+    make \
+    readline-devel \
+    tar \
+    uuid \
+    uuid-devel \
+    xz"
+# qtdeclarative provides the Qt Quick / Qml / QuickWidgets components and
+# qtquick3d the Quick3D component that OMEdit's CMake `find_package(Qt…
+# COMPONENTS Quick Quick3D Qml QuickWidgets)` requires. Both sets carry
+# qtdeclarative; only Qt6 carries qtquick3d (Qt5 has no qtquick3d on EL/Fedora),
+# which is why EL 9 / Fedora build against Qt6 rather than Qt5.
+ARG QT5_PKGS="\
+    qt5-linguist \
+    qt5-qt3d-devel \
+    qt5-qtbase-devel \
+    qt5-qtdeclarative-devel \
+    qt5-qtsvg-devel \
+    qt5-qttools \
+    qt5-qtwebkit-devel \
+    qt5-qtxmlpatterns-devel"
+ARG QT6_PKGS="\
+    qt6-linguist \
+    qt6-qt3d-devel \
+    qt6-qt5compat-devel \
+    qt6-qtbase-devel \
+    qt6-qtdeclarative-devel \
+    qt6-qthttpserver-devel \
+    qt6-qtquick3d-devel \
+    qt6-qtsvg-devel \
+    qt6-qttools-devel \
+    qt6-qtwebengine-devel"
+ARG FEDORA_PKGS="\
+    lpsolve-devel \
+    omniORB-devel"
+
+RUN dnf install -y dnf-plugins-core \
+  && . /etc/os-release \
+  # Fedora is matched by ID (its os-release leaves PLATFORM_ID empty); the EL
+  # family (almalinux/rocky/rhel) is matched by PLATFORM_ID (platform:elN).
+  && if [ "${ID}" = "fedora" ]; then \
+       case "${VERSION_ID}" in \
+         43 | 44) qt="${QT6_PKGS}" && extra="${FEDORA_PKGS}" ;; \
+         *) echo "Unsupported Fedora VERSION_ID: ${VERSION_ID}" >&2 && exit 1 ;; \
+       esac; \
+     else \
+       case "${PLATFORM_ID}" in \
+         platform:el8) \
+           dnf install -y epel-release \
+           && dnf config-manager --set-enabled powertools \
+           && qt="${QT5_PKGS}" \
+           && extra="autoconf2.7x gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-gcc-gfortran" ;; \
+         platform:el9) \
+           dnf install -y epel-release \
+           && dnf config-manager --set-enabled crb \
+           && qt="${QT6_PKGS}" \
+           && extra="autoconf2.7x" ;; \
+         platform:el10) \
+           dnf install -y epel-release \
+           && dnf config-manager --set-enabled crb \
+           && qt="${QT6_PKGS}" \
+           && extra="" ;; \
+         *) echo "Unsupported PLATFORM_ID: ${PLATFORM_ID}" >&2 && exit 1 ;; \
+       esac; \
+     fi \
+  && dnf -y upgrade \
+  && dnf install -y ${BUILD_PKGS} ${qt} ${extra} \
+  # EL 8/9 ship autoconf 2.69; OpenModelica's autoreconf needs 2.7x (EPEL's
+  # autoconf2.7x installs autoconf27/autoreconf27/…). Expose them unversioned.
+  && if command -v autoconf27 >/dev/null 2>&1; then \
+       ln -sf "$(command -v autoconf27)"   /usr/local/bin/autoconf; \
+       ln -sf "$(command -v autoreconf27)" /usr/local/bin/autoreconf; \
+       ln -sf "$(command -v autoheader27)" /usr/local/bin/autoheader; \
+       ln -sf "$(command -v autom4te27)"   /usr/local/bin/autom4te; \
+     fi \
+  # OMEdit's qmake-based pieces expect a plain `qmake`; EL 8/9 provide qmake-qt5.
+  && if [ ! -e /usr/bin/qmake ] && [ -e /usr/bin/qmake-qt5 ]; then \
+       ln -s /usr/bin/qmake-qt5 /usr/bin/qmake; \
+     fi \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
+
+# CI mounts fresh named volumes under /cache; Docker seeds an empty volume with
+# the mount point's image permissions, so create them world-writable for the
+# non-root Jenkins uid (sccache/runtest/omlibrary caches).
+RUN mkdir -p /cache/sccache /cache/runtest /cache/omlibrary \
+  && chmod -R 0777 /cache
+
+# ── venv: Python tooling, isolated so it caches independently ─────────────────
+# Built once and copied into `full`. Pins python3.12 explicitly (EL 9's default
+# python3 is 3.9, too old for current fmpy; python3.12 is packaged on EL 8/9/10
+# and Fedora), so `full` installs python3.12 as well and the relocated /opt/venv
+# works there unchanged regardless of the distro's default python3.
+FROM base AS venv
+# python3.12 bundles ensurepip, so `python3.12 -m venv` bootstraps pip without a
+# separate pip package (EL's python3.12-pip name does not exist on Fedora).
+RUN dnf install -y python3.12 \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
+RUN python3.12 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --no-cache-dir --upgrade pip
+# Use permalink for doc/UsersGuide/source/requirements.txt to keep builds
+# deterministic.
+RUN pip install --no-cache-dir \
+    fmpy==0.3.29 \
+    junit_xml \
+    lxml \
+    ompython==3.6.0 \
+    PyGithub \
+    simplejson \
+    svgwrite \
+  && pip install --no-cache-dir -r \
+    https://raw.githubusercontent.com/OpenModelica/OpenModelica/9c0dc9a8ab50ba652109584cb3fecaef86640b66/doc/UsersGuide/source/requirements.txt
+
+# ── full: the published base image ────────────────────────────────────────────
+#   - common tooling shared by all versions (git, ccache, doc tools, …)
+#   - the Python venv built in the `venv` stage
+FROM base AS full
+
+# COMMON_PKGS: tooling on top of the raw build dependencies (fetching sources,
+# faster rebuilds, the User's Guide / Doxygen toolchain). All from BaseOS/
+# AppStream/CRB/EPEL, which `base` already enabled.
+ARG COMMON_PKGS="\
+    ccache \
+    diffutils \
+    doxygen \
+    git \
+    graphviz \
+    patch \
+    python3.12 \
+    unzip \
+    wget \
+    which \
+    zip"
+RUN dnf install -y ${COMMON_PKGS} \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
+
+# Pull in the venv built in its own stage instead of rebuilding it here.
+COPY --from=venv /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage, shared image for the RPM-based distros: the enterprise family
-# AlmaLinux / Rocky Linux / RHEL (all EL = Enterprise Linux, i.e. the `rhel`
+# AlmaLinux / RHEL (all EL = Enterprise Linux, i.e. the `rhel`
 # family) and Fedora. A single Dockerfile covers EL 9, 10 and Fedora 43, 44;
 # DISTRO and VERSION are the only per-image differences, plus a handful of
 # distro-specific packages (Qt5 vs Qt6, EPEL/CRB, autoconf 2.7x, gcc-toolset,
@@ -22,12 +22,12 @@
 # Build the base image (the `full` target):
 #   docker build --target full --build-arg DISTRO=almalinux --build-arg VERSION=10 \
 #     --tag build-deps:almalinux-10 rpm
-#   docker build --target full --build-arg DISTRO=rockylinux --build-arg VERSION=10 \
-#     --tag build-deps:rockylinux-10 rpm
+#   docker build --target full --build-arg DISTRO=almalinux --build-arg VERSION=9 \
+#     --tag build-deps:almalinux-9 rpm
 #   docker build --target full --build-arg DISTRO=fedora --build-arg VERSION=44 \
 #     --tag build-deps:fedora-44 rpm
 #
-# RHEL: the public AlmaLinux / Rocky images are bug-for-bug EL rebuilds, so the
+# RHEL: the public AlmaLinux images are bug-for-bug EL rebuilds, so the
 # same recipe applies to a RHEL/UBI base — pass DISTRO/VERSION for a RHEL base
 # image (e.g. redhat/ubi9) that your build host is entitled to.
 #
@@ -57,21 +57,25 @@ ENV SHELL=/bin/bash \
 # Package lists as build-args, so they are easy to read and to override:
 #   - BUILD_PKGS  : build dependencies common to every distro (spec's
 #                   version-independent BuildRequires).
-#   - QT6_PKGS    : Qt6 build set for EL 9, EL 10 and Fedora. OMEdit's CMake
-#                   build needs Qt6 (the Quick3D component is effectively
-#                   Qt6-only on EL/Fedora), so everything with Qt6 available
-#                   uses it. qt6-qtbase-devel already ships /usr/bin/qmake.
-#   - QT5_PKGS    : Qt5 fallback for EL 8 only (no Qt6 in EL 8 AppStream). Note
-#                   EL 8 lacks qt5-qtquick3d, so an OMEdit build needing Quick3D
-#                   cannot be satisfied there; EL 8 is not in .ci/matrix.yml.
+#   - QT6_PKGS    : Qt6 build set for EL 10 and Fedora. qt6-qtbase-devel already
+#                   ships /usr/bin/qmake.
+#   - QT5_PKGS    : Qt5 build set for EL 8 and EL 9 — this matches upstream's
+#                   openmodelica.spec, which builds Qt5 on rhel <= 9 and reserves
+#                   Qt6 for EL 10. On EL 9, EPEL's Qt6 stack is currently
+#                   unbuildable anyway: qt6-linguist needs an LLVM (libclang) soname
+#                   that EL 9 AppStream no longer ships, and LinguistTools is a
+#                   required OMEdit Qt component. OMEdit's Quick3D animation backend
+#                   (Qt6-only) is opt-in (OM_OMEDIT_ANIMATION_QUICK3D, OFF by
+#                   default; OpenSceneGraph is the default), so Qt5 here is fine.
 #   - FEDORA_PKGS : Fedora-only BuildRequires the EL builds skip — omniORB/lpsolve
 #                   (the --with-omniORB branch, taken when rhel < 8, i.e. also on
 #                   Fedora). OMEdit's 3D animation uses Qt Quick 3D
 #                   (qt6-qtquick3d-devel, in QT6_PKGS), not OpenSceneGraph.
 # Distro-specific extras handled in the RUN case block below:
 #   - EL only : EPEL + CRB/powertools (Fedora needs neither).
-#   - EL 8/9  : autoconf 2.7x (from EPEL) symlinked as autoconf/autoreconf/…
-#   - EL 8    : gcc-toolset-11 (default gcc 8.5 is too old) + qmake -> qmake-qt5
+#   - EL 8/9  : autoconf 2.7x (from EPEL) symlinked as autoconf/autoreconf/…,
+#               Qt5 (QT5_PKGS) + qmake -> qmake-qt5
+#   - EL 8    : gcc-toolset-11 as well (default gcc 8.5 is too old)
 #   - EL 10   : nothing extra (new enough autoconf, qt6 already in QT6_PKGS)
 #   - Fedora  : new enough autoconf/gcc; qmake ships with qt6-qtbase-devel
 ARG BUILD_PKGS="\
@@ -102,11 +106,11 @@ ARG BUILD_PKGS="\
     uuid \
     uuid-devel \
     xz"
-# qtdeclarative provides the Qt Quick / Qml / QuickWidgets components and
-# qtquick3d the Quick3D component that OMEdit's CMake `find_package(Qt…
-# COMPONENTS Quick Quick3D Qml QuickWidgets)` requires. Both sets carry
+# qtdeclarative provides the Qt Quick / Qml / QuickWidgets components; qtquick3d
+# provides the Quick3D component of OMEdit's optional Qt Quick 3D animation
+# backend (OM_OMEDIT_ANIMATION_QUICK3D, OFF by default). Both sets carry
 # qtdeclarative; only Qt6 carries qtquick3d (Qt5 has no qtquick3d on EL/Fedora),
-# which is why EL 9 / Fedora build against Qt6 rather than Qt5.
+# so the Quick3D backend is only available on the Qt6 images (EL 10 / Fedora).
 ARG QT5_PKGS="\
     qt5-linguist \
     qt5-qt3d-devel \
@@ -134,7 +138,7 @@ ARG FEDORA_PKGS="\
 RUN dnf install -y dnf-plugins-core \
   && . /etc/os-release \
   # Fedora is matched by ID (its os-release leaves PLATFORM_ID empty); the EL
-  # family (almalinux/rocky/rhel) is matched by PLATFORM_ID (platform:elN).
+  # family (almalinux/rhel) is matched by PLATFORM_ID (platform:elN).
   && if [ "${ID}" = "fedora" ]; then \
        case "${VERSION_ID}" in \
          43 | 44) qt="${QT6_PKGS}" && extra="${FEDORA_PKGS}" ;; \
@@ -150,7 +154,7 @@ RUN dnf install -y dnf-plugins-core \
          platform:el9) \
            dnf install -y epel-release \
            && dnf config-manager --set-enabled crb \
-           && qt="${QT6_PKGS}" \
+           && qt="${QT5_PKGS}" \
            && extra="autoconf2.7x" ;; \
          platform:el10) \
            dnf install -y epel-release \

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -69,15 +69,20 @@ ENV SHELL=/bin/bash \
 #                   default; OpenSceneGraph is the default), so Qt5 here is fine.
 #   - FEDORA_PKGS : Fedora-only BuildRequires the EL builds skip — omniORB/lpsolve
 #                   (the --with-omniORB branch, taken when rhel < 8, i.e. also on
-#                   Fedora). OMEdit's 3D animation uses Qt Quick 3D
-#                   (qt6-qtquick3d-devel, in QT6_PKGS), not OpenSceneGraph.
+#                   Fedora).
+#   - OSG_PKGS    : OpenSceneGraph-devel, OMEdit's default 3D animation backend
+#                   (Qt Quick 3D is the opt-in alternative). Added on every distro
+#                   that packages it — EL 8/9 (from EPEL) and Fedora,
+#                   EL 10 dropped OpenSceneGraph entirely, so it has no OSG
+#                   backend and relies on Qt Quick 3D (Qt6) instead.
 # Distro-specific extras handled in the RUN case block below:
 #   - EL only : EPEL + CRB/powertools (Fedora needs neither).
 #   - EL 8/9  : autoconf 2.7x (from EPEL) symlinked as autoconf/autoreconf/…,
-#               Qt5 (QT5_PKGS) + qmake -> qmake-qt5
+#               Qt5 (QT5_PKGS) + qmake -> qmake-qt5, OpenSceneGraph-devel (OSG_PKGS)
 #   - EL 8    : gcc-toolset-11 as well (default gcc 8.5 is too old)
-#   - EL 10   : nothing extra (new enough autoconf, qt6 already in QT6_PKGS)
-#   - Fedora  : new enough autoconf/gcc; qmake ships with qt6-qtbase-devel
+#   - EL 10   : nothing extra (new enough autoconf, qt6 already in QT6_PKGS; no OSG)
+#   - Fedora  : new enough autoconf/gcc; qmake ships with qt6-qtbase-devel;
+#               OpenSceneGraph-devel (OSG_PKGS)
 ARG BUILD_PKGS="\
     automake \
     bison \
@@ -134,6 +139,7 @@ ARG QT6_PKGS="\
 ARG FEDORA_PKGS="\
     lpsolve-devel \
     omniORB-devel"
+ARG OSG_PKGS="OpenSceneGraph-devel"
 
 RUN dnf install -y dnf-plugins-core \
   && . /etc/os-release \
@@ -141,7 +147,7 @@ RUN dnf install -y dnf-plugins-core \
   # family (almalinux/rhel) is matched by PLATFORM_ID (platform:elN).
   && if [ "${ID}" = "fedora" ]; then \
        case "${VERSION_ID}" in \
-         43 | 44) qt="${QT6_PKGS}" && extra="${FEDORA_PKGS}" ;; \
+         43 | 44) qt="${QT6_PKGS}" && extra="${FEDORA_PKGS} ${OSG_PKGS}" ;; \
          *) echo "Unsupported Fedora VERSION_ID: ${VERSION_ID}" >&2 && exit 1 ;; \
        esac; \
      else \
@@ -150,16 +156,17 @@ RUN dnf install -y dnf-plugins-core \
            dnf install -y epel-release \
            && dnf config-manager --set-enabled powertools \
            && qt="${QT5_PKGS}" \
-           && extra="autoconf2.7x gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-gcc-gfortran" ;; \
+           && extra="autoconf2.7x gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-gcc-gfortran ${OSG_PKGS}" ;; \
          platform:el9) \
            dnf install -y epel-release \
            && dnf config-manager --set-enabled crb \
            && qt="${QT5_PKGS}" \
-           && extra="autoconf2.7x" ;; \
+           && extra="autoconf2.7x ${OSG_PKGS}" ;; \
          platform:el10) \
            dnf install -y epel-release \
            && dnf config-manager --set-enabled crb \
            && qt="${QT6_PKGS}" \
+           # EL 10 has no OpenSceneGraph package; OMEdit uses Qt Quick 3D (Qt6).
            && extra="" ;; \
          *) echo "Unsupported PLATFORM_ID: ${PLATFORM_ID}" >&2 && exit 1 ;; \
        esac; \


### PR DESCRIPTION
## Issue

* We need to support Enterprice Linux and Fedora

## Changes

Replace the rpm/Dockerfile placeholder with a multi-stage image (base/venv/full) for the RPM distros, from the OpenModelica spec BuildRequires and the apt-build Dockerfile.rpm-* templates.

- Dispatch: Fedora by ${ID} (empty PLATFORM_ID), EL by ${PLATFORM_ID}; EPEL + CRB/powertools and autoconf 2.7x/gcc-toolset on EL only.
- Qt6 on EL9/EL10/Fedora (Quick3D + LinguistTools); EL8 stays Qt5.
- Add clang, libuuid-devel, libstdc++-static; drop OpenSceneGraph (OMEdit uses Qt Quick 3D). Python venv on python3.12.
- Register almalinux-{9,10}, rockylinux-10, fedora-{43,44} in matrix.yml and README.