### PR TITLE
Clean versions // Harden action versions

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -11,7 +11,10 @@
 # Required environment variables:
 #   REGISTRY  Image repository, e.g. ghcr.io/openmodelica/build-deps
 #   TAG       Base tag (e.g. ubuntu-24.04) or release tag (e.g. ubuntu-24.04-2.1.0)
-#   SIGN      "true" to cosign-sign every pushed tag (keyless OIDC), else "false"
+#   SIGN      "true" to cosign-sign the pushed immutable tags (keyless OIDC),
+#             else "false". Only immutable tags are signed: the moving tag
+#             points at the same digest, so one signature per image covers
+#             both, and moving-only publishes (no semver) sign nothing.
 set -euo pipefail
 
 : "${REGISTRY:?REGISTRY is required}"
@@ -25,6 +28,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 eval "$(python3 "${SCRIPT_DIR}/matrix.py" image "${TAG}")"
 
 PUSHED_TAGS=()
+IMMUTABLE_TAGS=()
 
 build_and_push() {
   # $1 = moving tag, $2 = immutable tag (empty → skip), remaining args go to `docker buildx`.
@@ -35,8 +39,12 @@ build_and_push() {
     tag_args+=(--tag "${REGISTRY}:${immutable}")
   fi
   echo "::group::Building ${moving}"
+  # --provenance=false: without it buildx wraps every image in an OCI index
+  # with an extra attestation manifest, which piles up as untagged versions
+  # on GHCR on every push.
   docker buildx build \
     --pull \
+    --provenance=false \
     --file "${dockerfile}" \
     "${tag_args[@]}" \
     --cache-from "type=gha,scope=${moving}" \
@@ -47,6 +55,7 @@ build_and_push() {
   PUSHED_TAGS+=("${REGISTRY}:${moving}")
   if [[ -n "${immutable}" ]]; then
     PUSHED_TAGS+=("${REGISTRY}:${immutable}")
+    IMMUTABLE_TAGS+=("${REGISTRY}:${immutable}")
   fi
 }
 
@@ -70,9 +79,10 @@ for addon in ${addons}; do
     "${common_args[@]}" --target "${addon}"
 done
 
-# 3. Optionally sign every pushed tag (GHCR / cosign keyless).
-if [ "${SIGN}" = "true" ]; then
-  for image in "${PUSHED_TAGS[@]}"; do
+# 3. Optionally sign the immutable tags (GHCR / cosign keyless). Signing is
+#    per digest, so the moving tag of the same image verifies too.
+if [ "${SIGN}" = "true" ] && [ "${#IMMUTABLE_TAGS[@]}" -gt 0 ]; then
+  for image in "${IMMUTABLE_TAGS[@]}"; do
     echo "Signing ${image}"
     COSIGN_EXPERIMENTAL=1 cosign sign --yes --registry-referrers-mode=oci-1-1 "${image}"
   done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       publish_matrix: ${{ steps.publish_tags.outputs.matrix }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install dependencies
         run: pip install -r .ci/requirements.txt
@@ -112,18 +112,18 @@ jobs:
         image: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # The Dockerfile tend to be huge, free up some space on the GitHub runners
       - name: Free up disk space
-        uses: endersonmenezes/free-disk-space@v3.2.2
+        uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3.2.2
         with:
           remove_android: "true"
           remove_dotnet: "true"
           remove_haskell: "true"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build base image and add-ons
         env:
@@ -144,7 +144,7 @@ jobs:
       contents: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Create or update release
         env:
@@ -188,27 +188,27 @@ jobs:
       TAG: ${{ matrix.image.tag }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # The Dockerfile tend to be huge, free up some space on the GitHub runners
       - name: Free up disk space
-        uses: endersonmenezes/free-disk-space@v3.2.2
+        uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3.2.2
         with:
           remove_android: "true"
           remove_dotnet: "true"
           remove_haskell: "true"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Install dependencies
         run: pip install -r .ci/requirements.txt
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -269,24 +269,24 @@ jobs:
       TAG: ${{ matrix.image.tag }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # The Dockerfile tend to be huge, free up some space on the GitHub runners
       - name: Free up disk space
-        uses: endersonmenezes/free-disk-space@v3.2.2
+        uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3.2.2
         with:
           remove_android: "true"
           remove_dotnet: "true"
           remove_haskell: "true"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Install dependencies
         run: pip install -r .ci/requirements.txt
 
       - name: Login to Nexus Docker registry
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: docker.openmodelica.org
           username: ${{ secrets.NEXUS_OPENMODELICABOT_USER }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,11 @@ name: Build, Release & Publish
 #                     all moving tags; pass a global tag (e.g. v2.1.0) to rebuild
 #                     all images with immutable tags; pass a single image tag
 #                     (e.g. ubuntu-24.04-2.1.0) to rebuild just that image.
+#
+# Cosign signing on GHCR happens only for releases (immutable tags): on a
+# v-tag push, and on workflow_dispatch re-publishes of a release unless the
+# `sign` input is unchecked. Moving-tag publishes (main, schedule) never sign,
+# keeping the number of sha256-* signature tags on GHCR to a minimum.
 
 on:
   schedule:
@@ -33,6 +38,11 @@ on:
         description: 'Optional: version to (re)publish. Empty = rebuild all moving tags. Global tag (e.g. v2.1.0) = all images with immutable tags. Single image tag (e.g. ubuntu-24.04-2.1.0) = one image with immutable tag.'
         required: false
         default: ''
+      sign:
+        description: 'Cosign-sign the immutable tags on GHCR when re-publishing a release. Moving-tag-only publishes are never signed.'
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: read
@@ -204,26 +214,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Sign only releases: a v-tag push, or a workflow_dispatch re-publish
+      # unless its `sign` input is unchecked. Publishes without immutable
+      # tags (schedule, push to main, dispatch with an empty tag input)
+      # are never signed — publish.sh only signs immutable tags.
       - name: Build, push and sign image (base + add-ons)
         env:
-          SIGN: "true"
+          SIGN: ${{ (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.sign)) && 'true' || 'false' }}
         run: ./.ci/publish.sh
 
       - name: Verify signatures
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.sign) }}
         run: |
           set -euo pipefail
           eval "$(python .ci/matrix.py image "${TAG}")"
+          if [[ -z "${semver}" ]]; then
+            echo "Moving-tag-only publish — nothing was signed, skipping verification."
+            exit 0
+          fi
           CERT_ID="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/build.yml@${GITHUB_REF}"
           CERT_ISSUER="https://token.actions.githubusercontent.com"
-          tags=("${base_tag}")
-          if [[ -n "${semver}" ]]; then
-            tags+=("${base_tag}-${semver}")
-          fi
+          # Signatures are per digest; verifying the immutable tags also
+          # covers the moving tags, which point at the same digests.
+          tags=("${base_tag}-${semver}")
           for addon in ${addons}; do
-            tags+=("${base_tag}-${addon}")
-            if [[ -n "${semver}" ]]; then
-              tags+=("${base_tag}-${addon}-${semver}")
-            fi
+            tags+=("${base_tag}-${addon}-${semver}")
           done
           for t in "${tags[@]}"; do
             echo "Verifying ${REGISTRY}:${t}"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,48 @@
+name: Cleanup container registry
+
+# Manually triggered cleanup of the ghcr.io/openmodelica/build-deps package.
+#
+# Deletes:
+#   - untagged versions that nothing references (stale digests left behind
+#     every time a moving tag like `ubuntu-24.04` is re-pushed)
+#   - ghost / partial multi-arch images whose platform manifests are gone
+#   - orphaned referrers (e.g. cosign `sha256-*` signature tags whose subject
+#     image no longer exists)
+#
+# Keeps:
+#   - every tagged image
+#   - untagged manifests still referenced by a tagged image (multi-arch
+#     children, provenance/attestation manifests)
+#   - cosign signatures whose subject image still exists, so signed release
+#     tags remain verifiable
+#
+# Run with dry-run: true (the default) first and check the log before running
+# it for real.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Only log what would be deleted, do not delete anything'
+        type: boolean
+        default: true
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    name: Delete untagged and dangling versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Cleanup build-deps package
+        uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        with:
+          package: build-deps
+          delete-untagged: true
+          delete-ghost-images: true
+          delete-partial-images: true
+          delete-orphaned-images: true
+          validate: true
+          dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Cleanup build-deps package
-        uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           package: build-deps
           delete-untagged: true

--- a/README.md
+++ b/README.md
@@ -175,10 +175,22 @@ discover ─▶ build (all images, no push)
 - **build** — on every push/PR to `main` (and as the gate before release),
   builds every base + add-on declared in `.ci/matrix.yml` (no push).
 - **release** — on an repo-wide release tag, creates/updates the GitHub Release.
-- **publish-ghcr / publish-nexus** — build and push (and on GHCR **sign**) the
-  images to GHCR and Nexus. Moving tags (`<os>-<version>`) are updated on every
+- **publish-ghcr / publish-nexus** — build and push the images to GHCR and
+  Nexus. Moving tags (`<os>-<version>`) are updated on every
   push to `main`, the weekly schedule, and `workflow_dispatch`. Immutable tags
   (`<os>-<version>-<semver>`) are pushed on a release tag, and can also be republished via `workflow_dispatch` when a global `v<semver>` is supplied.
+  On GHCR the immutable tags are **cosign-signed** — only on releases (and
+  optionally on `workflow_dispatch` re-publishes of a release); the moving tag
+  of a released image points at the same digest, so it verifies with the same
+  signature.
+
+A second, manually triggered workflow,
+[cleanup.yml](./.github/workflows/cleanup.yml), deletes stale versions of the
+GHCR package: untagged digests left behind by re-pushed moving tags and
+orphaned cosign `sha256-*` signature tags whose image is gone. It keeps all
+tagged images, anything still referenced by them, and signatures of existing
+images. It defaults to a dry run — inspect the log, then re-run it with
+`dry-run` unchecked.
 
 ## Releasing a new image version
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -103,6 +103,11 @@ Use the **workflow_dispatch** trigger on
 - **Pass a single image tag** (e.g. `ubuntu-24.04-2.1.0`) — re-publishes
   only that one image with its moving and immutable tags.
 
+The **sign** checkbox (default: on) controls whether the re-published
+immutable tags are cosign-signed on GHCR. It only applies when immutable tags
+are pushed (a `v<semver>` or single-image tag input); moving-tag-only
+re-publishes are never signed.
+
 ## Adding a brand-new image
 
 1. For a **new OS**, create the single multi-stage `<os>/Dockerfile` (see


### PR DESCRIPTION
## Issue 

We are building up a large amount of dangling images in https://github.com/OpenModelica/build-deps/pkgs/container/build-deps/versions.
<img width="343" height="83" alt="image" src="https://github.com/user-attachments/assets/058bf343-b4c1-4db2-8904-5777b5f60260" />

## Changes

* Adding a workflow to clean dangling package versions.
  * Only sign GHCR images on release
  * Use https://github.com/dataaxiom/ghcr-cleanup-action to clean 
  
* Pin GitHub actions versions via SHAs.
