### PR TITLE
Run registry cleanup automatically after each GHCR publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ name: Build, Release & Publish
 #
 #   discover ─▶ build (all images, no push)
 #                 └─▶ release (tag only) ─▶ publish-ghcr + publish-nexus
+#                                             └─▶ cleanup (GHCR, no dry-run)
 #
 # Triggers:
 #   push main         Publishes every image with the moving tag (<os>-<version>).
@@ -247,6 +248,17 @@ jobs:
               --certificate-oidc-issuer="${CERT_ISSUER}" \
               "${REGISTRY}:${t}"
           done
+
+  # Prune superseded digests and orphaned signatures right after publishing,
+  # so re-pushed moving tags don't pile up as untagged versions on GHCR.
+  cleanup:
+    name: Cleanup container registry
+    needs: publish-ghcr
+    permissions:
+      packages: write
+    uses: ./.github/workflows/cleanup.yml
+    with:
+      dry-run: false
 
   publish-nexus:
     name: Publish ${{ matrix.image.tag }} to Nexus

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,6 +1,8 @@
 name: Cleanup container registry
 
-# Manually triggered cleanup of the ghcr.io/openmodelica/build-deps package.
+# Cleanup of the ghcr.io/openmodelica/build-deps package. Runs automatically
+# at the end of every publish (called from build.yml) and can be triggered
+# manually via workflow_dispatch.
 #
 # Deletes:
 #   - untagged versions that nothing references (stale digests left behind
@@ -16,8 +18,8 @@ name: Cleanup container registry
 #   - cosign signatures whose subject image still exists, so signed release
 #     tags remain verifiable
 #
-# Run with dry-run: true (the default) first and check the log before running
-# it for real.
+# When triggering manually, run with dry-run: true (the default) first and
+# check the log before running it for real.
 
 on:
   workflow_dispatch:
@@ -26,6 +28,13 @@ on:
         description: 'Only log what would be deleted, do not delete anything'
         type: boolean
         default: true
+  workflow_call:
+    inputs:
+      dry-run:
+        description: 'Only log what would be deleted, do not delete anything'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   packages: write

--- a/README.md
+++ b/README.md
@@ -184,13 +184,15 @@ discover ─▶ build (all images, no push)
   of a released image points at the same digest, so it verifies with the same
   signature.
 
-A second, manually triggered workflow,
-[cleanup.yml](./.github/workflows/cleanup.yml), deletes stale versions of the
-GHCR package: untagged digests left behind by re-pushed moving tags and
-orphaned cosign `sha256-*` signature tags whose image is gone. It keeps all
-tagged images, anything still referenced by them, and signatures of existing
-images. It defaults to a dry run — inspect the log, then re-run it with
-`dry-run` unchecked.
+A second workflow, [cleanup.yml](./.github/workflows/cleanup.yml), deletes
+stale versions of the GHCR package: untagged digests left behind by re-pushed
+moving tags and orphaned cosign `sha256-*` signature tags whose image is gone.
+It keeps all tagged images, anything still referenced by them, and signatures
+of existing images. It runs automatically after every successful GHCR publish
+and can also be triggered manually, where it defaults to a dry run — inspect
+the log, then re-run it with `dry-run` unchecked. Note that superseded digests
+are pruned right after each publish, so pulling a moving tag's previous image
+by digest is not supported.
 
 ## Releasing a new image version
 


### PR DESCRIPTION
Make cleanup.yml callable via workflow_call and invoke it from build.yml after publish-ghcr succeeds (dry-run disabled), so superseded moving-tag digests and orphaned signature tags are pruned in the same pipeline run. Manual workflow_dispatch stays available and still defaults to a dry run.