### PR TITLE
Add Arch Linux build-deps image (rolling release)

### DIFF
--- a/.ci/matrix.yml
+++ b/.ci/matrix.yml
@@ -148,12 +148,10 @@ images:
       VERSION: "43"
     addons: []
 
-  # Placeholders — not implemented yet. Uncomment and flesh out once the
-  # corresponding Dockerfile is real, so CI starts building them.
-  #
-  # - os: arch
-  #   version: "rolling"
-  #   context: pacman
-  #   dockerfile: pacman/Dockerfile
-  #   target: full
-  #   addons: []
+  # Arch Linux — rolling release with no version suffix.
+  - os: arch
+    version: "rolling"
+    context: pacman
+    dockerfile: pacman/Dockerfile
+    target: full
+    addons: []

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ main
 ├── rpm/
 │   └── Dockerfile          # multi-stage: AlmaLinux, RHEL, Fedora
 ├── pacman/
-│   └── Dockerfile          # placeholder (not implemented yet)
+│   └── Dockerfile          # multi-stage: Arch Linux + add-ons
 └── .ci/
     ├── matrix.yml          # source of truth: which images exist
     ├── matrix.py           # matrix.yml -> CI matrix / tag lookup
@@ -81,6 +81,7 @@ OpenModelica release needs a frozen environment it pins the **immutable** tag.
 | Debian 13 (Trixie)      | `debian-13`     | `cmake-4`, `debug`                | `apt/Dockerfile` |
 | Debian 12 (Bookworm)    | `debian-12`     | `cmake-4`, `debug`                | `apt/Dockerfile` |
 | Alpine 3.24             | `alpine-3.24`   | `omsimulator`                     | `apk/Dockerfile` |
+| Arch (rolling)          | `arch-rolling`  | –                                 | `pacman/Dockerfile` |
 | AlmaLinux 10            | `almalinux-10`  | –                                 | `rpm/Dockerfile` |
 | AlmaLinux 9             | `almalinux-9`   | –                                 | `rpm/Dockerfile` |
 | Fedora 44               | `fedora-44`     | –                                 | `rpm/Dockerfile` |
@@ -135,6 +136,17 @@ docker build --pull \
   --build-arg VERSION=3.24 \
   --tag build-deps:alpine-3.24-omsimulator \
   apk
+```
+
+**Arch Linux** uses the separate [pacman/Dockerfile][pacman-dockerfile] context.
+Arch is rolling-release with no version build-arg, and has no OpenModelica pacman
+repo, so the build dependencies are installed directly:
+
+```bash
+docker build --pull --no-cache \
+  --target full \
+  --tag build-deps:arch-rolling \
+  pacman
 ```
 
 **Enterprise Linux** (AlmaLinux, RHEL) and **Fedora** share
@@ -209,6 +221,7 @@ See [LICENSE.md][license-md].
 [matrix-yml]: ./.ci/matrix.yml
 [apt-dockerfile]: ./apt/Dockerfile
 [apk-dockerfile]: ./apk/Dockerfile
+[pacman-dockerfile]: ./pacman/Dockerfile
 [rpm-dockerfile]: ./rpm/Dockerfile
 [workflow-build-file]: ./.github/workflows/build.yml
 [releasing-md]: ./RELEASING.md

--- a/pacman/Dockerfile
+++ b/pacman/Dockerfile
@@ -1,25 +1,137 @@
-# PLACEHOLDER — OpenModelica build-deps image for Arch Linux.
+# Multi-stage, shared image for Arch Linux.
 #
-# Not implemented yet. Use the same layout as ../ubuntu/Dockerfile: a single
-# multi-stage Dockerfile, with these stages:
-#   base     OpenModelica build dependencies only
-#   venv     Python virtualenv at /opt/venv, built in isolation and copied later
-#   full     the published base image (build-deps:arch-rolling)
-#   <addon>  optional add-on stages (FROM full)
+# Arch is rolling-release with no version build-arg; uses archlinux:latest and
+# pins to date-stamped immutable tags (arch-rolling-YYYY.MM.DD) via CI/build.yml.
+# Arch has no OpenModelica pacman repository, so the build dependencies are
+# installed directly with pacman (there is no `apt build-dep` equivalent).
+# Package names were resolved against Arch's main repository.
 #
-# Arch is rolling-release, so there is no version build-arg:
-#   FROM archlinux:latest AS base
+# Stages / build targets:
+#   base        OpenModelica build dependencies (toolchain + core libraries)
+#   venv        Python virtualenv at /opt/venv, built in isolation and copied later
+#   full        the published BASE image: base + Qt6 + OpenSceneGraph + python venv
 #
-# Note: pacman-based, with no OpenModelica apt repo — install the build
-# dependencies directly with pacman, and pin reproducible snapshots via a
-# date-stamped immutable tag (arch-rolling-YYYY.MM.DD).
+# Build the base image (the `full` target):
+#   docker build --target full --tag build-deps:arch-rolling pacman
 #
-# To implement:
-#   1. Replace this file with a real multi-stage Dockerfile (see
-#      ../ubuntu/Dockerfile and RELEASING.md).
-#   2. Add the arch entry to .ci/matrix.yml
-#      (context: arch, dockerfile: arch/Dockerfile, target: full).
-#   3. Open a PR; build.yml will build it.
-#
-# Until then Arch is intentionally absent from .ci/matrix.yml, so CI does not try
-# to build it.
+# CI passes the --target per image from .ci/matrix.yml.
+
+# ── base: OpenModelica build dependencies only ────────────────────────────────
+FROM archlinux:latest AS base
+
+# Image / OCI metadata (inherited by the stages built FROM this one)
+LABEL maintainer="AnHeuermann" \
+      description="OpenModelica build-deps Docker Image" \
+      organization="OpenModelica"
+
+LABEL org.opencontainers.image.vendor="OpenModelica" \
+      org.opencontainers.image.authors="AnHeuermann" \
+      org.opencontainers.image.description="OpenModelica build-deps base image" \
+      org.opencontainers.image.source="https://github.com/OpenModelica/build-deps" \
+      org.opencontainers.image.license="MIT"
+
+ENV SHELL=/bin/bash \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+# Core toolchain and libraries needed to build the OpenModelica compiler.
+# Mirrors OMCompiler/README.Linux.md §1.2 (autotools/cmake, g++/gfortran, clang,
+# LAPACK/BLAS, hdf5, hwloc, boost, libcurl, expat, ncurses/readline, …).
+RUN pacman -Syu --noconfirm \
+  && pacman -S --noconfirm \
+    autoconf \
+    automake \
+    bash \
+    bison \
+    boost \
+    bzip2 \
+    ccache \
+    clang \
+    cmake \
+    coreutils \
+    curl \
+    expat \
+    flex \
+    gcc \
+    gcc-fortran \
+    git \
+    gnuplot \
+    hdf5 \
+    hwloc \
+    jq \
+    java-runtime-openjdk \
+    lapack \
+    libtool \
+    libxml2 \
+    libxslt \
+    linux-headers \
+    make \
+    ncurses \
+    openblas \
+    openmp \
+    openssl \
+    patch \
+    pkgconf \
+    readline \
+    tar \
+    unzip \
+    util-linux \
+    wget \
+    xz \
+    zip \
+    zlib
+
+# CI mounts fresh named volumes under /cache; Docker seeds an empty volume with
+# the mount point's image permissions, so create them world-writable for the
+# non-root Jenkins uid (sccache/runtest/omlibrary caches).
+RUN mkdir -p /cache/sccache /cache/runtest /cache/omlibrary \
+  && chmod -R 0777 /cache
+
+# ── venv: Python tooling, isolated so it caches independently ─────────────────
+# Built once and copied into `full`. Uses the same python3 as `full` (same
+# base image), so the relocated /opt/venv works there unchanged.
+FROM base AS venv
+RUN pacman -S --noconfirm python python-pip
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+# Use permalink for doc/UsersGuide/source/requirements.txt to keep builds
+# deterministic.
+RUN pip install --no-cache-dir \
+    fmpy==0.3.29 \
+    junit_xml \
+    lxml \
+    ompython==3.6.0 \
+    PyGithub \
+    simplejson \
+    svgwrite \
+  && pip install --no-cache-dir -r \
+    https://raw.githubusercontent.com/OpenModelica/OpenModelica/9c0dc9a8ab50ba652109584cb3fecaef86640b66/doc/UsersGuide/source/requirements.txt
+
+# ── full: the published base image ────────────────────────────────────────────
+#   - Qt6 for OMEdit (base + the modules OpenModelica links against)
+#   - OpenSceneGraph for the OMEdit 3D animation view
+#   - doc generators (doxygen, graphviz) and a few build utilities
+FROM base AS full
+
+# Package lists as build-args, so they are easy to read and to override.
+#   - QT_PKGS   : Qt6 modules OMEdit builds against
+#   - EXTRA_PKGS: OpenSceneGraph, doc generators and misc build utilities
+ARG QT_PKGS="\
+    qt6-base \
+    qt6-declarative \
+    qt6-httpserver \
+    qt6-quick3d \
+    qt6-scxml \
+    qt6-serialport \
+    qt6-shadertools \
+    qt6-svg \
+    qt6-tools \
+    qt6-websockets"
+ARG EXTRA_PKGS="\
+    doxygen \
+    openscenegraph"
+RUN pacman -S --noconfirm ${QT_PKGS} ${EXTRA_PKGS}
+
+# Pull in the venv built in its own stage instead of rebuilding it here.
+COPY --from=venv /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"


### PR DESCRIPTION
Implements the Arch Dockerfile with multi-stage build: base stage with OpenModelica build dependencies, venv stage for Python tooling, full stage with Qt6 and OpenSceneGraph, for GUI development. Updates matrix.yml to enable Arch builds in CI and documents the image in README with build instructions.