### PR TITLE
Make the copied /opt/cargo-xwin writable

### DIFF
--- a/apt/Dockerfile
+++ b/apt/Dockerfile
@@ -332,6 +332,9 @@ COPY --from=rustdeps /opt/Qt /opt/Qt
 COPY --from=rustdeps /opt/rust /opt/rust
 COPY --from=rustdeps /opt/cargo-xwin /opt/cargo-xwin
 
+# Not recursive - we don't want to duplicate the layer
+RUN chmod ugo+rwx /opt/cargo-xwin
+
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
   && apt-get install -qy \
     lld \


### PR DESCRIPTION
`COPY --from` preserves the mode of the files it copies, but creates the destination directory itself root-owned 0755 — so the `chmod ugo+rwx -R` in `rustdeps` reaches everything under /opt/cargo-xwin except /opt/cargo-xwin. cargo-xwin re-creates its `clang-cl` symlink there on every run, and nothing on `PATH` makes it skip that write, so every MSVC cross build in the image dies with:

    Error: Failed to setup clang-cl symlink
    Caused by:
        failed to symlink file from /opt/cargo-xwin/clang-cl to
        /usr/bin/clang: Permission denied (os error 13)

chmod the directory alone: its contents are already 0777, and -R would rewrite the modes of the whole CRT/SDK into this layer.