### PR TITLE
Prime zig under a throwaway CARGO_HOME

### DIFF
--- a/apt/Dockerfile
+++ b/apt/Dockerfile
@@ -347,14 +347,19 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Prime zig's libc/compiler_rt cache for the FMU-loader cross targets.
-RUN mkdir -p /tmp/zigprime/src && cd /tmp/zigprime \
+# Prime zig's libc/compiler_rt cache for the FMU-loader cross targets. Under its
+# own CARGO_HOME: running cargo as root in the shared one leaves a root-owned
+# $CARGO_HOME/.package-cache behind, and when cargo cannot open that file it
+# drops the package cache lock *silently* (it tolerates a read-only CARGO_HOME),
+# so concurrent cargo processes corrupt each other's git checkouts.
+RUN export CARGO_HOME=/tmp/zigprime-cargo \
+  && mkdir -p /tmp/zigprime/src && cd /tmp/zigprime \
   && printf '[package]\nname = "zigprime"\nversion = "0.0.0"\nedition = "2021"\n[lib]\ncrate-type = ["cdylib"]\n' > Cargo.toml \
   && echo '#[no_mangle] pub extern "C" fn zigprime() {}' > src/lib.rs \
   && for t in aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin; do \
        cargo zigbuild --release --target "$t" || exit 1; \
      done \
-  && cd / && rm -rf /tmp/zigprime \
+  && cd / && rm -rf /tmp/zigprime /tmp/zigprime-cargo \
   && chmod ugo+rwx -R /opt/zig-cache /opt/cargo-zigbuild
 
 # ── OMSimulator add-on: full + X11 dev libs OMSimulator's GUI links against ───


### PR DESCRIPTION
The priming runs cargo as root in the shared /opt/rust/cargo, which leaves a root-owned $CARGO_HOME/.package-cache behind -- after the `chmod ugo+rwx -R /opt/rust` in rustdeps, so nothing widens it again.

A non-root uid then cannot open that file, and cargo does not fail on that: it tolerates a read-only CARGO_HOME by dropping the package cache lock *silently* (no "Blocking waiting for file lock" is ever printed). Concurrent cargo processes in one container -- normal under `cmake --build -j` -- then race in $CARGO_HOME/git, and one wipes a checkout the other is still writing:

    error: failed to load source for dependency `libffi-sys`
    Caused by:
      could not open '/opt/rust/cargo/git/checkouts/libffi-rs-<hash>/
      <rev>/libffi-sys-rs/libffi/m4/ax_gcc_x86_cpuid.m4' for writing:
      No such file or directory; class=Os (2)

with the dependency and the file varying per run (`blitz-dom` and `libffi-sys` both seen). Verified by reproducing it locally: four concurrent `cargo fetch`es on a git dependency serialise normally, and race exactly like this the moment .package-cache cannot be opened.

Keep the priming out of the shared cargo home entirely rather than chmod'ing afterwards, which would rewrite /opt/rust/cargo into a new layer.