### PR TITLE
Use zig from PyPI instead of apt

### DIFF
--- a/apt/Dockerfile
+++ b/apt/Dockerfile
@@ -342,10 +342,14 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update \
     libclang-rt-dev-wasm32 \
     wine \
     mold \
-    zig \
     llvm \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+# zig from apt is too old
+ARG ZIGLANG_VERSION="0.16.0"
+RUN pip install --no-cache-dir "ziglang==${ZIGLANG_VERSION}" \
+  && cargo zigbuild --version && python3 -m ziglang version
 
 # Prime zig's libc/compiler_rt cache for the FMU-loader cross targets. Under its
 # own CARGO_HOME: running cargo as root in the shared one leaves a root-owned


### PR DESCRIPTION
cargo-zigbuild only stops passing `--sysroot` to zig at zig 0.15. Below that, and with a macOS SDK named by SDKROOT, zig re-roots *every* -L under the SDK, so an `*-apple-darwin` link fails on libraries that are plainly there:

    warning: unable to open library directory
      '/mnt/MacOSX.sdk/mnt/MacOSX.sdk/usr/lib': FileNotFound
    warning: unable to open library directory
      '/mnt/MacOSX.sdk/opt/cargo-zigbuild/cargo-zigbuild/0.23.0/deps'
    error: unable to find dynamic system library 'iconv' using strategy
      'paths_first'. searched paths: none

-- the SDK's own lib directory doubled, and cargo-zigbuild's deps directory (where it puts the libiconv/libcharset .tbd stubs it supplies for exactly this link) moved under the SDK too.

Ubuntu's zig is older than 0.15, so drop it and install the PyPI ziglang, which cargo-zigbuild prefers anyway: it looks for `python3 -m ziglang` before the `zig` binary. Pinned, like the other tools whose version the Rust build depends on, and verified in the same layer so a bad pin fails the image build rather than a cross build much later.